### PR TITLE
feat(termix): add Termix web terminal manager stack

### DIFF
--- a/termix/compose.yaml
+++ b/termix/compose.yaml
@@ -1,0 +1,43 @@
+networks:
+  npm:
+    external: true
+  termix-net:
+    driver: bridge
+
+services:
+  termix:
+    image: ghcr.io/lukegus/termix:release-2.0.0@sha256:78ee50bb5274106456eaa2e1826fca9e477570d82e0f30fde66b6a1421005d56
+    container_name: termix
+    restart: unless-stopped
+    volumes:
+      - termix-data:/app/data
+    environment:
+      PORT: '8080'
+    depends_on:
+      - guacd
+    networks:
+      - npm
+      - termix-net
+    labels:
+      - traefik.enable=true
+      - traefik.docker.network=npm
+      - traefik.http.routers.termix.rule=Host(`termix.${DOMAIN}`)
+      - traefik.http.routers.termix.entrypoints=websecure
+      - traefik.http.routers.termix.tls=true
+      - traefik.http.services.termix.loadbalancer.server.port=8080
+      - homepage.group=Tools
+      - homepage.name=Termix
+      - homepage.icon=termix.png
+      - homepage.href=https://termix.${DOMAIN}/
+      - homepage.description=Web-based terminal manager
+
+  guacd:
+    image: guacamole/guacd:1.6.0@sha256:2d266a525a72ad55d8ea7cd4ca8342a1b44075759b03660d8684821b3636a922
+    container_name: guacd
+    restart: unless-stopped
+    networks:
+      - termix-net
+
+volumes:
+  termix-data:
+    driver: local


### PR DESCRIPTION
## Summary

- Adds [Termix](https://github.com/lukegus/termix) (v2.0.0), a web-based terminal manager backed by Apache Guacamole's `guacd` daemon
- Both images pinned to `linux/amd64` SHA256 digests for reproducibility
- Termix exposed via Traefik at `termix.${DOMAIN}` (HTTPS)
- `guacd` kept on an internal `termix-net` bridge — not publicly exposed
- Named Docker volume `termix-data` for persistence
- Homepage dashboard entry under **Tools** group

## Reviewer notes

- `traefik.docker.network=npm` is set on the `termix` service because it joins two networks (`npm` + `termix-net`)
- No secrets or hardcoded values; `${DOMAIN}` is injected by Komodo at deploy time
- Renovate will track both `ghcr.io/lukegus/termix` and `guacamole/guacd` automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)