### PR TITLE
fix(renovate): add allowUnsafeSshCommand to fix simple-git security block

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "allowUnsafeSshCommand": true,
   "extends": [
     "config:recommended",
     ":enableVulnerabilityAlerts"


### PR DESCRIPTION
## Probleem

Renovate v43+ stelt intern `GIT_SSH_COMMAND` in als onderdeel van zijn Docker image SSH-setup. De meegeleverde `simple-git@3.36.0` bevat een `block-unsafe-operations-plugin` die dit detecteert en blokkeert — waardoor Renovate faalt op de eerste git operatie (`ls-remote`).

Foutmelding in de logs:
```
Use of "GIT_SSH_COMMAND" is not permitted without enabling allowUnsafeSshCommand
```

De variabele staat nergens expliciet in compose.yaml of .env — Renovate zet hem zelf intern.

> PR #1770 was een verkeerde fix (`GIT_SSH_COMMAND=` leeg in compose werkt niet: de sleutel bestaat dan nog steeds in `process.env` en triggert de check alsnog).

## Fix

`allowUnsafeSshCommand: true` toegevoegd aan `renovate.json`. Dit is de gedocumenteerde Renovate-optie om zijn eigen interne `GIT_SSH_COMMAND` te mogen gebruiken.