### PR TITLE
fix(renovate): restore compose.yaml + add RENOVATE_ALLOW_UNSAFE_SSH_COMMAND

### DIFF
--- a/renovate/compose.yaml
+++ b/renovate/compose.yaml
@@ -54,8 +54,7 @@ services:
       # Optional: Additional configuration
       - RENOVATE_AUTODISCOVER=${RENOVATE_AUTODISCOVER:-false}
       - RENOVATE_INCLUDE_FORKS=${RENOVATE_INCLUDE_FORKS:-false}
-      # Prevent simple-git from blocking GIT_SSH_COMMAND (renovate/simple-git security plugin)
-      - GIT_SSH_COMMAND=
+      - RENOVATE_ALLOW_UNSAFE_SSH_COMMAND=true
       # Docker Hub authentication using Renovate's built-in support
       - RENOVATE_DOCKER_USERNAME=${DOCKERHUB_USERNAME}
       - RENOVATE_DOCKER_PASSWORD=${DOCKERHUB_TOKEN}


### PR DESCRIPTION
## Wat er misging

PR #1772 had een lege compose.yaml door een fout in de base64-pipeline. Dit PR herstelt de originele compose en voegt de juiste fix toe.

## Fix

`RENOVATE_ALLOW_UNSAFE_SSH_COMMAND=true` toegevoegd als environment variable. Renovate laadt dit bij opstarten, vóór de eerste git operatie — in tegenstelling tot `renovate.json` (PR #1771) dat te laat wordt gelezen.