### PR TITLE
fix(renovate): bump to 43.130.1 to fix GIT_SSH_COMMAND error

### DIFF
--- a/renovate/compose.yaml
+++ b/renovate/compose.yaml
@@ -32,7 +32,7 @@ services:
 
   # One-time Renovate run
   renovate:
-    image: renovate/renovate:43.129.1@sha256:e4da2f6d43063eb3cc4852243c52c5be316080eaaec8d0173c2718d4b23d3083
+    image: renovate/renovate:43.130.1
     depends_on:
       token-generator:
         condition: service_completed_successfully


### PR DESCRIPTION
Renovate 43.129.1 bundelt simple-git 3.36.0, dat `GIT_SSH_COMMAND` blokkeert via een nieuwe security plugin. Dit breekt alle self-hosted Renovate installaties.

Opgelost in 43.130.1. Zie: https://github.com/renovatebot/renovate/discussions/42740