### PR TITLE
refactor(renovate): replace npm deps with native Node.js crypto and fetch

### DIFF
--- a/renovate/compose.yaml
+++ b/renovate/compose.yaml
@@ -15,17 +15,11 @@ services:
     restart: "no"  # Don't restart, just run once
     command: >
       sh -c "
-        echo 'Installing dependencies...'
-        npm install --silent jsonwebtoken @octokit/rest
-        echo 'Generating GitHub App installation token...'
-        node src/generate-token.js > /app/token/token.txt 2>&1
+        node src/generate-token.js > /app/token/token.txt
         if [ $? -eq 0 ]; then
           echo 'Token generated successfully'
-          cat /app/token/token.txt | head -c 20
-          echo '...'
         else
-          echo 'Token generation failed:'
-          cat /app/token/token.txt
+          echo 'Token generation failed'
           exit 1
         fi
       "

--- a/renovate/token-generator/generate-token.js
+++ b/renovate/token-generator/generate-token.js
@@ -1,79 +1,55 @@
 #!/usr/bin/env node
 
 const fs = require('fs');
-const jwt = require('jsonwebtoken');
+const { createSign } = require('crypto');
 
-// Configuration from environment variables
 const APP_ID = process.env.APP_ID;
 const PRIVATE_KEY_PATH = process.env.PRIVATE_KEY_PATH || '/app/private-key.pem';
 const INSTALLATION_ID = process.env.INSTALLATION_ID;
 const GITHUB_API_URL = process.env.GITHUB_API_URL || 'https://api.github.com';
 
-// Validation
-if (!APP_ID) {
-  console.error('ERROR: APP_ID environment variable is required');
-  process.exit(1);
-}
-
-if (!INSTALLATION_ID) {
-  console.error('ERROR: INSTALLATION_ID environment variable is required');
-  process.exit(1);
-}
-
-if (!fs.existsSync(PRIVATE_KEY_PATH)) {
-  console.error(`ERROR: Private key file not found at ${PRIVATE_KEY_PATH}`);
-  process.exit(1);
-}
+if (!APP_ID) { console.error('ERROR: APP_ID environment variable is required'); process.exit(1); }
+if (!INSTALLATION_ID) { console.error('ERROR: INSTALLATION_ID environment variable is required'); process.exit(1); }
 
 async function generateInstallationToken() {
+  let privateKey;
   try {
-    // Dynamic import of ES module
-    const { Octokit } = await import('@octokit/rest');
-    
-    // Read the private key
-    const privateKey = fs.readFileSync(PRIVATE_KEY_PATH, 'utf8');
-    
-    // Create JWT for GitHub App authentication
-    const now = Math.floor(Date.now() / 1000);
-    const payload = {
-      iat: now - 60, // Issued at time (60 seconds ago to account for clock drift)
-      exp: now + (10 * 60), // Expiration time (10 minutes from now)
-      iss: APP_ID // Issuer (GitHub App ID)
-    };
-    
-    const token = jwt.sign(payload, privateKey, { algorithm: 'RS256' });
-    
-    // Create Octokit instance with GitHub App token
-    const octokit = new Octokit({
-      auth: token,
-      baseUrl: GITHUB_API_URL
-    });
-    
-    // Generate installation access token
-    const { data } = await octokit.rest.apps.createInstallationAccessToken({
-      installation_id: INSTALLATION_ID,
-      // Optional: specify repositories if you want to limit scope
-      // repositories: ['repo1', 'repo2'],
-    });
-    
-    // Output only the token (this will be captured by the shell command)
-    console.log(data.token);
-    
-  } catch (error) {
-    console.error('ERROR: Failed to generate installation token:', error.message);
-    
-    // Provide more specific error messages
-    if (error.status === 401) {
-      console.error('Authentication failed. Check your APP_ID and private key.');
-    } else if (error.status === 404) {
-      console.error('Installation not found. Check your INSTALLATION_ID.');
-    } else if (error.code === 'ENOENT') {
-      console.error('Private key file not found.');
-    }
-    
+    privateKey = fs.readFileSync(PRIVATE_KEY_PATH, 'utf8');
+  } catch {
+    console.error(`ERROR: Private key file not found at ${PRIVATE_KEY_PATH}`);
     process.exit(1);
   }
+
+  const now = Math.floor(Date.now() / 1000);
+  const header = Buffer.from(JSON.stringify({ alg: 'RS256', typ: 'JWT' })).toString('base64url');
+  const payload = Buffer.from(JSON.stringify({ iat: now - 60, exp: now + 600, iss: APP_ID })).toString('base64url');
+  const signingInput = `${header}.${payload}`;
+  const sign = createSign('RSA-SHA256');
+  sign.update(signingInput);
+  const jwtToken = `${signingInput}.${sign.sign(privateKey, 'base64url')}`;
+
+  const response = await fetch(
+    `${GITHUB_API_URL}/app/installations/${INSTALLATION_ID}/access_tokens`,
+    {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${jwtToken}`,
+        Accept: 'application/vnd.github+json',
+        'X-GitHub-Api-Version': '2022-11-28',
+      },
+    }
+  );
+
+  if (!response.ok) {
+    const body = await response.text().catch(() => '');
+    if (response.status === 401) console.error('ERROR: Authentication failed. Check APP_ID and private key.');
+    else if (response.status === 404) console.error('ERROR: Installation not found. Check INSTALLATION_ID.');
+    else console.error(`ERROR: GitHub API returned ${response.status}: ${body}`);
+    process.exit(1);
+  }
+
+  const { token } = await response.json();
+  console.log(token);
 }
 
-// Run the token generation
 generateInstallationToken();


### PR DESCRIPTION
## Summary

- Rewrites `token-generator/generate-token.js` to use Node's built-in `crypto.createSign` (RS256 JWT signing) and native `fetch` instead of `jsonwebtoken` and `@octokit/rest`
- Removes the `npm install` step from the token-generator container startup — no more network calls, version drift, or transitive dependency risk on every Renovate run
- Fixes a bug where `2>&1` in the compose command caused error output to be written into `token.txt`, which Renovate would then read as the token and fail with a confusing auth error

## Test plan

- [ ] Run `docker compose run --rm token-generator` and confirm it exits 0 and writes a non-empty `token.txt`
- [ ] Confirm `token.txt` starts with `ghs_`
- [ ] Run the full stack and confirm Renovate authenticates successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)