### PR TITLE
Add SigNoz self-hosted observability stack

### DIFF
--- a/signoz/compose.yaml
+++ b/signoz/compose.yaml
@@ -1,0 +1,223 @@
+services:
+  # ---------------------------------------------------------------------------
+  # Metastore: Postgres backing the SigNoz application (users, dashboards, etc.)
+  # ---------------------------------------------------------------------------
+  signoz-metastore-postgres-0:
+    container_name: signoz-metastore-postgres-0
+    image: postgres:16@sha256:287eced1f33b59ed265ed13a60d3680dd7646d70c4dc0e785f59a470ebc03eeb
+    restart: unless-stopped
+    environment:
+      - POSTGRES_DB=signoz
+      - POSTGRES_USER=signoz
+      - POSTGRES_PASSWORD=${SIGNOZ_POSTGRES_PASSWORD:-signoz}
+    healthcheck:
+      test:
+        - CMD-SHELL
+        - pg_isready -U signoz -d signoz
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
+    volumes:
+      - ${DOCKER_DATA_DIR}/signoz/postgres:/var/lib/postgresql/data
+    networks:
+      - signoz-network
+
+  # ---------------------------------------------------------------------------
+  # Telemetry keeper: ClickHouse Keeper (coordination for ClickHouse)
+  # ---------------------------------------------------------------------------
+  signoz-telemetrykeeper-clickhousekeeper-0:
+    container_name: signoz-telemetrykeeper-clickhousekeeper-0
+    image: clickhouse/clickhouse-keeper:25.5.6@sha256:5dd09e84fec538d5a65ec7191545d0ced2405c5f4f24692e279db29d281eb2ee
+    restart: unless-stopped
+    entrypoint:
+      - /usr/bin/clickhouse-keeper
+      - --config-file=/etc/clickhouse-keeper/keeper.yaml
+    healthcheck:
+      test:
+        - CMD
+        - clickhouse-keeper-client
+        - -h
+        - localhost
+        - -p
+        - "9181"
+        - -q
+        - ls
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s
+    volumes:
+      - ${DOCKER_DATA_DIR}/signoz/clickhouse-keeper:/var/lib/clickhouse-keeper
+      - ./telemetrykeeper/clickhousekeeper/keeper-0.yaml:/etc/clickhouse-keeper/keeper.yaml:ro
+    networks:
+      - signoz-network
+
+  # ---------------------------------------------------------------------------
+  # One-shot init: downloads the histogramQuantile UDF binary for ClickHouse
+  # ---------------------------------------------------------------------------
+  signoz-telemetrystore-clickhouse-user-scripts:
+    container_name: signoz-telemetrystore-clickhouse-user-scripts
+    image: clickhouse/clickhouse-server:25.5.6@sha256:4536143e22dc9bddb217c7e610f6b7ed5e6efd8fefdbc61acdeadb5d8022213a
+    command:
+      - bash
+      - -c
+      - |-
+        version="v0.0.1"
+        node_os=$$(uname -s | tr '[:upper:]' '[:lower:]')
+        node_arch=$$(uname -m | sed s/aarch64/arm64/ | sed s/x86_64/amd64/)
+        echo "Fetching histogram-binary for $${node_os}/$${node_arch}"
+        cd /tmp
+        wget -O histogram-quantile.tar.gz "https://github.com/SigNoz/signoz/releases/download/histogram-quantile%2F$${version}/histogram-quantile_$${node_os}_$${node_arch}.tar.gz"
+        tar -xvzf histogram-quantile.tar.gz
+        mv histogram-quantile /var/lib/clickhouse/user_scripts/histogramQuantile
+    volumes:
+      - ${DOCKER_DATA_DIR}/signoz/clickhouse-user-scripts:/var/lib/clickhouse/user_scripts
+    networks:
+      - signoz-network
+
+  # ---------------------------------------------------------------------------
+  # Telemetry store: ClickHouse (traces, logs, metrics)
+  # ---------------------------------------------------------------------------
+  signoz-telemetrystore-clickhouse-0-0:
+    container_name: signoz-telemetrystore-clickhouse-0-0
+    image: clickhouse/clickhouse-server:25.5.6@sha256:4536143e22dc9bddb217c7e610f6b7ed5e6efd8fefdbc61acdeadb5d8022213a
+    restart: unless-stopped
+    environment:
+      - CLICKHOUSE_SKIP_USER_SETUP=1
+      - CLICKHOUSE_CONFIG=/etc/clickhouse-server/config.yaml
+    healthcheck:
+      test:
+        - CMD
+        - wget
+        - --spider
+        - -q
+        - http://localhost:8123/ping
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s
+    volumes:
+      - ${DOCKER_DATA_DIR}/signoz/clickhouse:/var/lib/clickhouse
+      - ${DOCKER_DATA_DIR}/signoz/clickhouse-user-scripts:/var/lib/clickhouse/user_scripts:ro
+      - ./telemetrystore/clickhouse/config-0-0.yaml:/etc/clickhouse-server/config.yaml:ro
+      - ./telemetrystore/clickhouse/functions.yaml:/etc/clickhouse-server/functions.yaml:ro
+    depends_on:
+      signoz-telemetrykeeper-clickhousekeeper-0:
+        condition: service_healthy
+      signoz-telemetrystore-clickhouse-user-scripts:
+        condition: service_completed_successfully
+    networks:
+      - signoz-network
+
+  # ---------------------------------------------------------------------------
+  # One-shot migrator: bootstraps and migrates the ClickHouse schema
+  # ---------------------------------------------------------------------------
+  signoz-telemetrystore-migrator:
+    container_name: signoz-telemetrystore-migrator
+    image: signoz/signoz-otel-collector:v0.144.5@sha256:f9bf94d566055d06581f3befbf361cc26d670f31ad00cb31fda2ec380210c5ec
+    entrypoint:
+      - /bin/sh
+    command:
+      - -c
+      - |
+        /signoz-otel-collector migrate ready &&
+        /signoz-otel-collector migrate bootstrap &&
+        /signoz-otel-collector migrate sync up &&
+        /signoz-otel-collector migrate async up
+    environment:
+      - SIGNOZ_OTEL_COLLECTOR_CLICKHOUSE_DSN=tcp://signoz-telemetrystore-clickhouse-0-0:9000
+      - SIGNOZ_OTEL_COLLECTOR_TIMEOUT=10m
+    depends_on:
+      signoz-telemetrystore-clickhouse-0-0:
+        condition: service_healthy
+    networks:
+      - signoz-network
+
+  # ---------------------------------------------------------------------------
+  # SigNoz application + UI (exposed via Traefik on signoz.${DOMAIN})
+  # ---------------------------------------------------------------------------
+  signoz-signoz-0:
+    container_name: signoz-signoz-0
+    image: signoz/signoz:v0.130.1@sha256:fc27454618b38461b800cd437af36881dfb4e3cce21cf24a40418427833338d9
+    restart: unless-stopped
+    environment:
+      - SIGNOZ_SQLSTORE_PROVIDER=postgres
+      - SIGNOZ_SQLSTORE_POSTGRES_DSN=postgres://signoz:${SIGNOZ_POSTGRES_PASSWORD:-signoz}@signoz-metastore-postgres-0:5432/signoz?sslmode=disable
+      - SIGNOZ_TELEMETRYSTORE_PROVIDER=clickhouse
+      - SIGNOZ_TELEMETRYSTORE_CLICKHOUSE_DSN=tcp://signoz-telemetrystore-clickhouse-0-0:9000
+    healthcheck:
+      test:
+        - CMD
+        - wget
+        - --spider
+        - -q
+        - http://localhost:8080/api/v1/health
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 60s
+    depends_on:
+      signoz-metastore-postgres-0:
+        condition: service_healthy
+      signoz-telemetrystore-clickhouse-0-0:
+        condition: service_healthy
+      signoz-telemetrystore-migrator:
+        condition: service_completed_successfully
+    networks:
+      - signoz-network
+      - npm
+    labels:
+      # Homepage
+      - homepage.group=Infra
+      - homepage.name=SigNoz
+      - homepage.icon=signoz.png
+      - homepage.href=https://signoz.${DOMAIN}/
+      - homepage.description=Observability (traces, logs, metrics)
+
+      # Traefik
+      - traefik.enable=true
+      - traefik.docker.network=npm
+      - traefik.http.routers.signoz.rule=Host(`signoz.${DOMAIN}`)
+      - traefik.http.routers.signoz.entrypoints=websecure
+      - traefik.http.routers.signoz.tls=true
+      - traefik.http.services.signoz.loadbalancer.server.port=8080
+
+  # ---------------------------------------------------------------------------
+  # Ingester: OpenTelemetry collector receiving OTLP from your apps on the npm
+  # network (grpc 4317 / http 4318 — reachable in-cluster as signoz-ingester)
+  # ---------------------------------------------------------------------------
+  signoz-ingester:
+    container_name: signoz-ingester
+    image: signoz/signoz-otel-collector:v0.144.5@sha256:f9bf94d566055d06581f3befbf361cc26d670f31ad00cb31fda2ec380210c5ec
+    restart: unless-stopped
+    entrypoint:
+      - /bin/sh
+    command:
+      - -c
+      - |
+        /signoz-otel-collector migrate sync check &&
+        /signoz-otel-collector --config=/etc/otel-collector-config.yaml --manager-config=/etc/opamp-config.yaml --copy-path=/var/tmp/collector-config.yaml
+    environment:
+      - SIGNOZ_OTEL_COLLECTOR_CLICKHOUSE_DSN=tcp://signoz-telemetrystore-clickhouse-0-0:9000
+      - SIGNOZ_OTEL_COLLECTOR_TIMEOUT=10m
+      - LOW_CARDINAL_EXCEPTION_GROUPING=false
+    volumes:
+      - ./ingester/ingester.yaml:/etc/otel-collector-config.yaml:ro
+      - ./ingester/opamp.yaml:/etc/opamp-config.yaml:ro
+    depends_on:
+      signoz-signoz-0:
+        condition: service_healthy
+    networks:
+      signoz-network:
+        aliases:
+          - signoz-ingester
+      npm:
+        aliases:
+          - signoz-ingester
+
+networks:
+  signoz-network:
+    name: signoz-network
+  npm:
+    external: true

--- a/signoz/ingester/ingester.yaml
+++ b/signoz/ingester/ingester.yaml
@@ -1,0 +1,132 @@
+connectors:
+  signozmeter:
+    dimensions:
+    - name: service.name
+    - name: deployment.environment
+    - name: host.name
+    metrics_flush_interval: 1h
+exporters:
+  clickhouselogsexporter:
+    dsn: tcp://signoz-telemetrystore-clickhouse-0-0:9000/signoz_logs
+    sending_queue:
+      enabled: false
+    timeout: 45s
+    use_new_schema: true
+  clickhousetraces:
+    datasource: tcp://signoz-telemetrystore-clickhouse-0-0:9000/signoz_traces
+    low_cardinal_exception_grouping: ${env:LOW_CARDINAL_EXCEPTION_GROUPING}
+    sending_queue:
+      enabled: false
+    timeout: 45s
+    use_new_schema: true
+  metadataexporter:
+    cache:
+      provider: in_memory
+    dsn: tcp://signoz-telemetrystore-clickhouse-0-0:9000/signoz_metadata
+    enabled: true
+    timeout: 45s
+  signozclickhousemeter:
+    dsn: tcp://signoz-telemetrystore-clickhouse-0-0:9000/signoz_meter
+    sending_queue:
+      enabled: false
+    timeout: 45s
+  signozclickhousemetrics:
+    dsn: tcp://signoz-telemetrystore-clickhouse-0-0:9000/signoz_metrics
+    sending_queue:
+      enabled: false
+    timeout: 45s
+extensions:
+  pprof:
+    endpoint: 0.0.0.0:1777
+  signoz_health_check:
+    endpoint: 0.0.0.0:13133
+processors:
+  batch:
+    send_batch_max_size: 55000
+    send_batch_size: 50000
+    timeout: 5s
+  batch/meter:
+    send_batch_max_size: 25000
+    send_batch_size: 20000
+    timeout: 5s
+  signozspanmetrics/delta:
+    aggregation_temporality: AGGREGATION_TEMPORALITY_DELTA
+    dimensions:
+    - default: default
+      name: service.namespace
+    - default: default
+      name: deployment.environment
+    - name: signoz.collector.id
+    - name: service.version
+    dimensions_cache_size: 100000
+    enable_exp_histogram: true
+    latency_histogram_buckets:
+    - 100us
+    - 1ms
+    - 2ms
+    - 6ms
+    - 10ms
+    - 50ms
+    - 100ms
+    - 250ms
+    - 500ms
+    - 1000ms
+    - 1400ms
+    - 2000ms
+    - 5s
+    - 10s
+    - 20s
+    - 40s
+    - 60s
+    metrics_exporter: signozclickhousemetrics
+    metrics_flush_interval: 60s
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+      http:
+        endpoint: 0.0.0.0:4318
+service:
+  extensions:
+  - signoz_health_check
+  - pprof
+  pipelines:
+    logs:
+      exporters:
+      - clickhouselogsexporter
+      - signozmeter
+      - metadataexporter
+      processors:
+      - batch
+      receivers:
+      - otlp
+    metrics:
+      exporters:
+      - signozclickhousemetrics
+      - signozmeter
+      - metadataexporter
+      processors:
+      - batch
+      receivers:
+      - otlp
+    metrics/meter:
+      exporters:
+      - signozclickhousemeter
+      processors:
+      - batch/meter
+      receivers:
+      - signozmeter
+    traces:
+      exporters:
+      - clickhousetraces
+      - signozmeter
+      - metadataexporter
+      processors:
+      - signozspanmetrics/delta
+      - batch
+      receivers:
+      - otlp
+  telemetry:
+    logs:
+      encoding: json

--- a/signoz/ingester/opamp.yaml
+++ b/signoz/ingester/opamp.yaml
@@ -1,0 +1,1 @@
+server_endpoint: ws://signoz-signoz-0:4320/v1/opamp

--- a/signoz/telemetrykeeper/clickhousekeeper/keeper-0.yaml
+++ b/signoz/telemetrykeeper/clickhousekeeper/keeper-0.yaml
@@ -1,0 +1,22 @@
+keeper_server:
+  coordination_settings:
+    force_sync: false
+    operation_timeout_ms: 10000
+    raft_logs_level: warning
+    session_timeout_ms: 30000
+    snapshot_distance: 100000
+    snapshots_to_keep: 3
+  four_letter_word_white_list: '*'
+  log_storage_path: /var/lib/clickhouse/coordination/log
+  raft_configuration:
+    server:
+    - hostname: signoz-telemetrykeeper-clickhousekeeper-0
+      id: 0
+      port: 9234
+  server_id: 0
+  snapshot_storage_path: /var/lib/clickhouse/coordination/snapshots
+  tcp_port: 9181
+listen_host: 0.0.0.0
+logger:
+  console: true
+  level: information

--- a/signoz/telemetrystore/clickhouse/config-0-0.yaml
+++ b/signoz/telemetrystore/clickhouse/config-0-0.yaml
@@ -1,0 +1,96 @@
+asynchronous_metric_log:
+  ttl: event_date + INTERVAL 1 DAY DELETE
+dictionaries_config: '*_dictionary.xml'
+display_name: cluster
+distributed_ddl:
+  path: /clickhouse/task_queue/ddl
+error_log:
+  ttl: event_date + INTERVAL 1 DAY DELETE
+format_schema_path: /var/lib/clickhouse/format_schemas/
+http_port: 8123
+interserver_http_port: 9009
+latency_log:
+  ttl: event_date + INTERVAL 1 DAY DELETE
+listen_host: 0.0.0.0
+logger:
+  console: 1
+  count: 10
+  formatting:
+    type: console
+  level: information
+  size: 1000M
+macros:
+  replica: "00"
+  shard: "00"
+metric_log:
+  flush_interval_milliseconds: 30000
+  ttl: event_date + INTERVAL 1 DAY DELETE
+part_log:
+  ttl: event_date + INTERVAL 1 DAY DELETE
+path: /var/lib/clickhouse/
+processors_profile_log:
+  flush_interval_milliseconds: 30000
+  ttl: event_date + INTERVAL 1 DAY DELETE
+profiles:
+  default:
+    allow_simdjson: 0
+    load_balancing: random
+    log_queries: 1
+query_log:
+  flush_interval_milliseconds: 30000
+  partition_by: toYYYYMM(event_date)
+  ttl: event_date + INTERVAL 1 DAY DELETE
+query_metric_log:
+  ttl: event_date + INTERVAL 1 DAY DELETE
+query_thread_log:
+  ttl: event_date + INTERVAL 1 DAY DELETE
+query_views_log:
+  ttl: event_date + INTERVAL 1 DAY DELETE
+quotas:
+  default:
+    interval:
+      duration: 3600
+      errors: 0
+      execution_time: 0
+      queries: 0
+      read_rows: 0
+      result_rows: 0
+remote_servers:
+  cluster:
+    shard:
+    - replica:
+      - host: signoz-telemetrystore-clickhouse-0-0
+        port: 9000
+session_log:
+  ttl: event_date + INTERVAL 1 DAY DELETE
+tcp_port: 9000
+text_log:
+  flush_interval_milliseconds: 30000
+  ttl: event_date + INTERVAL 1 DAY DELETE
+tmp_path: /var/lib/clickhouse/tmp/
+trace_log:
+  flush_interval_milliseconds: 30000
+  ttl: event_date + INTERVAL 1 DAY DELETE
+user_defined_executable_functions_config: '*function.yaml'
+user_directories:
+  users_xml:
+    path: users.xml
+user_files_path: /var/lib/clickhouse/user_files/
+user_scripts_path: /var/lib/clickhouse/user_scripts/
+users:
+  default:
+    access_management: 1
+    named_collection_control: 1
+    networks:
+      ip: ::/0
+    password: ""
+    profile: default
+    quota: default
+    show_named_collection: 1
+    show_named_collection_secrets: 1
+zookeeper:
+  node:
+  - host: signoz-telemetrykeeper-clickhousekeeper-0
+    port: 9181
+zookeeper_log:
+  ttl: event_date + INTERVAL 1 DAY DELETE

--- a/signoz/telemetrystore/clickhouse/functions.yaml
+++ b/signoz/telemetrystore/clickhouse/functions.yaml
@@ -1,0 +1,13 @@
+functions:
+  argument:
+  - name: buckets
+    type: Array(Float64)
+  - name: counts
+    type: Array(Float64)
+  - name: quantile
+    type: Array(Float64)
+  command: ./histogramQuantile
+  format: CSV
+  name: histogramQuantile
+  return_type: Float64
+  type: executable


### PR DESCRIPTION
## Summary

Adds a new `signoz/` stack running SigNoz self-hosted, based on SigNoz's current supported (Foundry-generated) Docker Compose, adapted to this repo's conventions.

## Services (7)

- **signoz-signoz-0** — UI/app, exposed via Traefik at `signoz.${DOMAIN}` (port 8080)
- **signoz-ingester** — OpenTelemetry collector; OTLP `4317` (gRPC) / `4318` (HTTP), reachable in-cluster on the `npm` network as `signoz-ingester` (no host ports published)
- **signoz-telemetrystore-clickhouse-0-0** + **signoz-telemetrykeeper-clickhousekeeper-0** — ClickHouse + Keeper
- **signoz-metastore-postgres-0** — Postgres metastore
- One-shot init jobs: histogramQuantile UDF download + ClickHouse schema migrator

## Conventions applied

- All images pinned to version + SHA256 digest (no floating tags)
- Persistent data via bind mounts under `${DOCKER_DATA_DIR}/signoz/...`
- Backend services isolated on internal `signoz-network`; only the UI and ingester join the external `npm` network
- Traefik + Homepage labels on the UI
- Postgres password parametrized via `${SIGNOZ_POSTGRES_PASSWORD}`
- ClickHouse/Keeper/collector runtime configs kept as mounted files (mirrors how Traefik dynamic config is stored in this repo)

## Required env

`DOCKER_DATA_DIR`, `DOMAIN`, `SIGNOZ_POSTGRES_PASSWORD`

## Notes

- Homepage icon label uses `signoz.png` — confirm it exists in the icon set.
- `docker compose config` validates cleanly.