### PR TITLE
Add OTel Collector agent stack for SigNoz container monitoring

### DIFF
--- a/otel-collector/compose.yaml
+++ b/otel-collector/compose.yaml
@@ -1,0 +1,26 @@
+services:
+  # ---------------------------------------------------------------------------
+  # OpenTelemetry Collector agent: scrapes Docker container stats, host metrics
+  # and container logs, and forwards them to the SigNoz ingester (OTLP gRPC).
+  # View the data in SigNoz under Infra Monitoring -> Containers / Hosts.
+  # ---------------------------------------------------------------------------
+  otel-collector:
+    container_name: otel-collector
+    image: otel/opentelemetry-collector-contrib:0.155.0@sha256:4935caa35e9a4cb387e35732e8fb22b2b5759af8d12e7043357f03837f6e8df5
+    restart: unless-stopped
+    command:
+      - --config=/etc/otelcol-contrib/config.yaml
+    user: "0:0"
+    environment:
+      - TZ=${TZ}
+    volumes:
+      - ./config.yaml:/etc/otelcol-contrib/config.yaml:ro
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - /var/lib/docker/containers:/var/lib/docker/containers:ro
+      - /:/hostfs:ro
+    networks:
+      - npm
+
+networks:
+  npm:
+    external: true

--- a/otel-collector/config.yaml
+++ b/otel-collector/config.yaml
@@ -1,0 +1,129 @@
+# OpenTelemetry Collector (agent) — scrapes the Docker host and ships
+# container metrics, host metrics and container logs to the SigNoz ingester.
+receivers:
+  # Per-container CPU / memory / network / disk stats via the Docker API.
+  docker_stats:
+    endpoint: unix:///var/run/docker.sock
+    collection_interval: 30s
+    timeout: 20s
+    api_version: "1.44"
+    metrics:
+      container.cpu.utilization:
+        enabled: true
+      container.memory.percent:
+        enabled: true
+      container.network.io.usage.rx_bytes:
+        enabled: true
+      container.network.io.usage.tx_bytes:
+        enabled: true
+      container.blockio.io_service_bytes_recursive:
+        enabled: true
+
+  # Host-level metrics (CPU, memory, disk, filesystem, network).
+  hostmetrics:
+    collection_interval: 30s
+    root_path: /hostfs
+    scrapers:
+      cpu: {}
+      load: {}
+      memory: {}
+      network: {}
+      disk: {}
+      filesystem:
+        exclude_mount_points:
+          mount_points:
+            - /dev/*
+            - /proc/*
+            - /sys/*
+            - /run/*
+            - /var/lib/docker/*
+            - /snap/*
+            - /boot/*
+          match_type: regexp
+        exclude_fs_types:
+          fs_types:
+            - autofs
+            - binfmt_misc
+            - cgroup
+            - cgroup2
+            - configfs
+            - debugfs
+            - devpts
+            - devtmpfs
+            - mqueue
+            - overlay
+            - proc
+            - procfs
+            - pstore
+            - squashfs
+            - sysfs
+            - tmpfs
+            - tracefs
+          match_type: strict
+
+  # Container stdout/stderr logs from the Docker json-file driver.
+  filelog/containers:
+    include:
+      - /var/lib/docker/containers/*/*-json.log
+    start_at: end
+    include_file_path: true
+    include_file_name: false
+    operators:
+      - type: json_parser
+        id: parser-docker
+        timestamp:
+          parse_from: attributes.time
+          layout: "%Y-%m-%dT%H:%M:%S.%LZ"
+      - type: regex_parser
+        id: extract_container_id
+        regex: '^.*containers/(?P<container_id>[^/]+)/.*\.log$'
+        parse_from: attributes["log.file.path"]
+      - type: move
+        from: attributes.container_id
+        to: resource["container.id"]
+      - type: move
+        from: attributes.log
+        to: body
+      - type: remove
+        field: attributes.time
+
+processors:
+  resourcedetection/system:
+    detectors:
+      - env
+      - system
+    system:
+      hostname_sources:
+        - os
+  batch:
+    send_batch_size: 10000
+    timeout: 10s
+
+exporters:
+  otlp:
+    endpoint: signoz-ingester:4317
+    tls:
+      insecure: true
+
+service:
+  pipelines:
+    metrics:
+      receivers:
+        - docker_stats
+        - hostmetrics
+      processors:
+        - resourcedetection/system
+        - batch
+      exporters:
+        - otlp
+    logs:
+      receivers:
+        - filelog/containers
+      processors:
+        - resourcedetection/system
+        - batch
+      exporters:
+        - otlp
+  telemetry:
+    logs:
+      encoding: json


### PR DESCRIPTION
## What

Adds a new `otel-collector/` stack: an OpenTelemetry Collector agent that scrapes the Docker host and ships telemetry to the existing `signoz-ingester` over OTLP gRPC.

## Why

Off-the-shelf containers (Plex, Sonarr, Immich, etc.) don't emit code-level APM traces, so the SigNoz **APM/Services** tab can't cover them. This collector provides **infrastructure monitoring** instead — the realistic way to monitor 60+ running containers.

## Sources → SigNoz

- `docker_stats` → per-container CPU / memory / network / block-IO
- `hostmetrics` → host CPU, load, memory, disk, filesystem, network
- `filelog` → container stdout/stderr logs (json-file driver), tagged with `container.id`

View under **Infra Monitoring → Containers / Hosts** and **Logs**.

## Notes

- Image SHA-pinned (`otel/opentelemetry-collector-contrib:0.155.0`), joins the external `npm` network to reach `signoz-ingester:4317`.
- Mounts the Docker socket (read-only), container log dir, and host root at `/hostfs`.
- Assumes the default `json-file` Docker log driver. If switched to `journald`/`local`, the log pipeline needs a tweak.
- For any app you control that supports OTel, point it at `http://signoz-ingester:4317` to populate the APM tab.