### PR TITLE
ci(renovate): group clickhouse server+keeper to prevent version skew

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -129,6 +129,21 @@
       ]
     },
     {
+      "description": "ClickHouse: group server and keeper together so they never drift in version. NOTE: grouping alone does NOT block a server-only bump when clickhouse-keeper has no matching tag yet (keeper is published on Docker Hub later than server). Renovate has no native 'wait for a sibling image to publish' option, so a residual skew window can still occur until keeper catches up. The minimumReleaseAge rule below softens this by delaying fresh tags; treat any clickhouse PR that bumps only one of the two images as DO-NOT-MERGE until the matching tag exists for the other.",
+      "matchDatasources": [
+        "docker"
+      ],
+      "matchPackageNames": [
+        "/clickhouse\\/clickhouse-server/",
+        "/clickhouse\\/clickhouse-keeper/"
+      ],
+      "groupName": "clickhouse",
+      "groupSlug": "clickhouse",
+      "addLabels": [
+        "clickhouse"
+      ]
+    },
+    {
       "description": "Group updates strictly per compose file directory",
       "matchManagers": [
         "docker-compose"
@@ -149,7 +164,9 @@
         "!/^docker\\.io\\/redis\\//",
         "!/^ghcr\\.io\\/immich-app\\/postgres/",
         "!/^ghcr\\.io\\/immich-app\\/immich-server/",
-        "!/^ghcr\\.io\\/immich-app\\/immich-machine-learning/"
+        "!/^ghcr\\.io\\/immich-app\\/immich-machine-learning/",
+        "!/clickhouse\\/clickhouse-server/",
+        "!/clickhouse\\/clickhouse-keeper/"
       ]
     },
     {


### PR DESCRIPTION
## Why

Renovate PR #2174 bumped `clickhouse/clickhouse-server` from `26.5.3` → `26.6.1` in `signoz/compose.yaml` but left `clickhouse/clickhouse-keeper` at `26.5.3`, creating a ClickHouse **Server/Keeper version skew**.

Root cause: `clickhouse-keeper:26.6.1` is not yet published on Docker Hub (keeper lags server), so at that Renovate run there was no keeper update to bundle. Both images already fell into the same `stack: signoz` group, but the server bump still went out alone because the keeper sibling had no matching tag.

## What this changes

`renovate.json`:

- Adds a dedicated **`clickhouse`** package group (mirroring the existing `immich-apps` grouping rule) matching both `clickhouse/clickhouse-server` and `clickhouse/clickhouse-keeper`, placed before the generic per-directory grouping rule.
- Excludes both clickhouse images from the generic `stack: {{parentDir}}` rule so they land in their own group with a `clickhouse` label.

## Residual limitation (documented in-file)

Grouping **cannot** force a hard "wait for the sibling image to publish" — Renovate has no native option for that, and keeper is published later than server. So a skew window can still occur until keeper catches up. The rule's `description` documents this explicitly, and the existing `minimumReleaseAge` (12h) softens fresh-tag churn. The operational guidance: any clickhouse PR that bumps only one of the two images should be treated as DO-NOT-MERGE until the matching tag exists for the other.

Validated with `renovate-config-validator` — no new errors introduced (the pre-existing `minimumReleaseAgeBehaviour` warning is unrelated to this change).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>