### PR TITLE
Scrape app Prometheus /metrics into SigNoz via otel-collector

### DIFF
--- a/otel-collector/compose.yaml
+++ b/otel-collector/compose.yaml
@@ -13,6 +13,14 @@ services:
     user: "0:0"
     environment:
       - TZ=${TZ}
+      # Credentials/identifiers for Prometheus scrape targets, referenced in
+      # config.yaml as ${env:VAR}. Komodo injects these from the env files.
+      - UPTIME_KUMA_METRICS_USER=${UPTIME_KUMA_METRICS_USER}
+      - UPTIME_KUMA_METRICS_PASSWORD=${UPTIME_KUMA_METRICS_PASSWORD}
+      - HEALTHCHECKS_PROJECT_UUID=${HEALTHCHECKS_PROJECT_UUID}
+      - HEALTHCHECKS_METRICS_KEY=${HEALTHCHECKS_METRICS_KEY}
+      - SLSKD_METRICS_USERNAME=${SLSKD_METRICS_USERNAME}
+      - SLSKD_METRICS_PASSWORD=${SLSKD_METRICS_PASSWORD}
     volumes:
       - ./config.yaml:/etc/otelcol-contrib/config.yaml:ro
       - /var/run/docker.sock:/var/run/docker.sock:ro

--- a/otel-collector/config.yaml
+++ b/otel-collector/config.yaml
@@ -87,6 +87,57 @@ receivers:
       - type: remove
         field: attributes.time
 
+  # Scrape Prometheus /metrics endpoints exposed by self-hosted apps on the
+  # `npm` network. Each job sets a stable job name so the source is easy to
+  # find in SigNoz (Metrics Explorer -> filter by `job`).
+  prometheus:
+    config:
+      scrape_configs:
+        # Immich API metrics. Requires IMMICH_TELEMETRY_INCLUDE=all on the
+        # immich-server container (set by the OTLP/telemetry stack, not here).
+        - job_name: immich-api
+          scrape_interval: 30s
+          metrics_path: /metrics
+          static_configs:
+            - targets: ["immich-server:8081"]
+
+        # Immich microservices metrics (same container, separate port).
+        - job_name: immich-microservices
+          scrape_interval: 30s
+          metrics_path: /metrics
+          static_configs:
+            - targets: ["immich-server:8082"]
+
+        # Uptime-Kuma per-monitor metrics. /metrics is protected by basic auth
+        # (login credentials or an API key).
+        - job_name: uptime-kuma
+          scrape_interval: 30s
+          metrics_path: /metrics
+          basic_auth:
+            username: ${env:UPTIME_KUMA_METRICS_USER}
+            password: ${env:UPTIME_KUMA_METRICS_PASSWORD}
+          static_configs:
+            - targets: ["uptime-kuma:3001"]
+
+        # Healthchecks check/tag status metrics. The read-only API key is part
+        # of the metrics path (no separate auth header).
+        - job_name: healthchecks
+          scrape_interval: 30s
+          metrics_path: /projects/${env:HEALTHCHECKS_PROJECT_UUID}/metrics/${env:HEALTHCHECKS_METRICS_KEY}
+          static_configs:
+            - targets: ["healthchecks:8000"]
+
+        # slskd transfer/performance metrics. Endpoint shares the public web
+        # port, so basic auth is kept enabled.
+        - job_name: slskd
+          scrape_interval: 30s
+          metrics_path: /metrics
+          basic_auth:
+            username: ${env:SLSKD_METRICS_USERNAME}
+            password: ${env:SLSKD_METRICS_PASSWORD}
+          static_configs:
+            - targets: ["slskd:5030"]
+
 processors:
   resourcedetection/system:
     detectors:
@@ -111,6 +162,7 @@ service:
       receivers:
         - docker_stats
         - hostmetrics
+        - prometheus
       processors:
         - resourcedetection/system
         - batch

--- a/slskd/compose.yaml
+++ b/slskd/compose.yaml
@@ -7,6 +7,9 @@ services:
       - PGID=${PGID}
       - TZ=Europe/Amsterdam
       - SLSKD_REMOTE_CONFIGURATION=true
+      - SLSKD_METRICS=true
+      - SLSKD_METRICS_USERNAME=${SLSKD_METRICS_USERNAME}
+      - SLSKD_METRICS_PASSWORD=${SLSKD_METRICS_PASSWORD}
     volumes:
       - ${DOCKER_DATA_DIR}/slskd:/app
       - ${MEDIA_DIR}/downloads/slskd:/media/downloads/slskd


### PR DESCRIPTION
## What

Adds a `prometheus` receiver to the **existing** infra collector (`otel-collector/`) and wires it into the `metrics` pipeline, so self-hosted apps that expose a Prometheus `/metrics` endpoint are scraped over the `npm` network and shipped to `signoz-ingester:4317`. No new stack; `signoz/` untouched.

## Apps now scraped

| Job (`job` label) | Target | Notes |
|---|---|---|
| `immich-api` | `immich-server:8081/metrics` | Immich API metrics |
| `immich-microservices` | `immich-server:8082/metrics` | Immich microservices metrics |
| `uptime-kuma` | `uptime-kuma:3001/metrics` | per-monitor status/response time, basic auth |
| `healthchecks` | `healthchecks:8000/projects/{uuid}/metrics/{key}` | check/tag status, read-only key in path |
| `slskd` | `slskd:5030/metrics` | transfer/perf metrics, basic auth |

All at 30s scrape interval.

## What was enabled

- **slskd** (`slskd/compose.yaml`): added `SLSKD_METRICS=true` plus `SLSKD_METRICS_USERNAME`/`SLSKD_METRICS_PASSWORD`. The metrics endpoint shares slskd's Traefik-exposed web port, so **auth is kept on** — no `SLSKD_METRICS_NO_AUTH`.
- **Immich**: scrape config only. The `/metrics` ports require `IMMICH_TELEMETRY_INCLUDE=all` on the `immich-server` container. ⚠️ **Dependency:** this env is owned by the parallel native-OTLP session — these two Immich jobs return data only once that flag is set. The compose for `immich-app/` is intentionally **not** modified here.

## New env vars the operator must set

Komodo only substitutes `${VAR}` in compose files (not in the mounted `config.yaml`), so secrets are passed through the collector's compose `environment:` and referenced as `${env:VAR}` in the config. Add these to the relevant Komodo env files:

- `UPTIME_KUMA_METRICS_USER`, `UPTIME_KUMA_METRICS_PASSWORD` — Uptime-Kuma login or API-key credentials for `/metrics`
- `HEALTHCHECKS_PROJECT_UUID`, `HEALTHCHECKS_METRICS_KEY` — project UUID + a **read-only** API key
- `SLSKD_METRICS_USERNAME`, `SLSKD_METRICS_PASSWORD` — credentials for slskd's metrics endpoint (must match on both slskd and the collector)

## Skipped (verified no native Prometheus support)

- **TeslaMate** — no `prom_ex`/telemetry metrics dependency in `mix.exs`; metrics come from Grafana-on-Postgres, not Prometheus.
- **Gotify** — no metrics option in its config.
- **Tautulli** — no native endpoint (needs a third-party exporter).

## Finding the metrics in SigNoz

Metrics Explorer → filter by the `job` label (`immich-api`, `uptime-kuma`, `slskd`, etc.). Example series: `monitor_response_time`/`monitor_status` (Uptime-Kuma), `hc_check_up` (Healthchecks).

Komodo auto-deploys on merge.