### PR TITLE
Enable native OTLP tracing export to SigNoz for supported apps

### DIFF
--- a/immich-app/compose.yaml
+++ b/immich-app/compose.yaml
@@ -18,6 +18,11 @@ services:
       - DB_PASSWORD=${DB_PASSWORD}
       - DB_USERNAME=${DB_USERNAME}
       - DB_DATABASE_NAME=${DB_DATABASE_NAME}
+      # Telemetry: export traces to SigNoz ingester (OTLP HTTP, plaintext)
+      - IMMICH_TELEMETRY_INCLUDE=all
+      - OTEL_TRACES_EXPORTER=otlp
+      - OTEL_EXPORTER_OTLP_ENDPOINT=http://signoz-ingester:4318
+      - OTEL_SERVICE_NAME=immich
     devices:
       - /dev/dri:/dev/dri
     networks:

--- a/komodo/compose.yaml
+++ b/komodo/compose.yaml
@@ -19,6 +19,8 @@ services:
       KOMODO_FIRST_SERVER: https://periphery:8120
       KOMODO_HOST: https://komodo.${DOMAIN}
       KOMODO_LOCAL_AUTH: false
+      KOMODO_LOGGING_OTLP_ENDPOINT: http://signoz-ingester:4317
+      KOMODO_LOGGING_OPENTELEMETRY_SERVICE_NAME: komodo-core
       KOMODO_OIDC_CLIENT_ID: ${KOMODO_OIDC_CLIENT_ID}
       KOMODO_OIDC_CLIENT_SECRET: ${KOMODO_OIDC_CLIENT_SECRET}
       KOMODO_OIDC_ENABLED: true
@@ -80,6 +82,8 @@ services:
       - "999"  # docker group
     environment:
       PERIPHERY_PASSKEYS: ${KOMODO_PASSKEY}
+      PERIPHERY_LOGGING_OTLP_ENDPOINT: http://signoz-ingester:4317
+      PERIPHERY_LOGGING_OPENTELEMETRY_SERVICE_NAME: komodo-periphery
       PERIPHERY_PORT: '8120'
       PERIPHERY_ROOT_DIRECTORY: ${DOCKER_DATA_DIR}/komodo/periphery
       PERIPHERY_SSL_ENABLED: true

--- a/traefik/compose.yaml
+++ b/traefik/compose.yaml
@@ -52,6 +52,12 @@ services:
       - --api.dashboard=true
       - --api.insecure=false
 
+      # Tracing (OpenTelemetry -> SigNoz ingester, OTLP gRPC, plaintext)
+      - --tracing.serviceName=traefik
+      - --tracing.otlp.grpc=true
+      - --tracing.otlp.grpc.endpoint=signoz-ingester:4317
+      - --tracing.otlp.grpc.insecure=true
+
       # Logging
       - --log.level=INFO
       - --accesslog=true


### PR DESCRIPTION
## Summary
Wires the apps that have native OpenTelemetry support to export traces/metrics to the existing SigNoz collector (`signoz-ingester`) on the external `npm` network, using plaintext OTLP. Once Komodo redeploys these stacks, they show up in SigNoz's **APM / Services** tab.

Config was verified against each app's **deployed image version** before editing. `signoz/` and `otel-collector/` are untouched.

## Per-app changes

### ✅ Traefik (`traefik/`, `v3.7.5`)
Native v3 OTel tracing via CLI flags (matches the existing `command:` style):
- `--tracing.serviceName=traefik`
- `--tracing.otlp.grpc=true`
- `--tracing.otlp.grpc.endpoint=signoz-ingester:4317`
- `--tracing.otlp.grpc.insecure=true`

Gives request-level traces for **every routed service**.

### ✅ Immich (`immich-app/`, `v2.7.5`)
Source (`telemetry.repository.ts`) shows the OTel `NodeSDK` only boots when `IMMICH_TELEMETRY_INCLUDE` is set, then falls back to the standard OTLP env vars. Added to `immich-server` (covers the api + microservices workers):
- `IMMICH_TELEMETRY_INCLUDE=all`
- `OTEL_TRACES_EXPORTER=otlp`
- `OTEL_EXPORTER_OTLP_ENDPOINT=http://signoz-ingester:4318` (OTLP HTTP, JS SDK default protocol)
- `OTEL_SERVICE_NAME=immich`

### ✅ Komodo (`komodo/`, `2.2.0`)
- `core`: `KOMODO_LOGGING_OTLP_ENDPOINT=http://signoz-ingester:4317`, `KOMODO_LOGGING_OPENTELEMETRY_SERVICE_NAME=komodo-core`
- `periphery`: `PERIPHERY_LOGGING_OTLP_ENDPOINT=http://signoz-ingester:4317`, `PERIPHERY_LOGGING_OPENTELEMETRY_SERVICE_NAME=komodo-periphery`

### ⛔ Authentik (`authentik/`, `2026.5.3`) — skipped
No configurable OTLP/OpenTelemetry trace export in this version — it only exposes Prometheus metrics (`AUTHENTIK_LISTEN__METRICS` :9300). The sole `opentelemetry` import in the source is transitive, inside the Microsoft Entra provider client, not an app-wide configurable tracer. Skipped rather than forced.

## Notes
- All target containers were already attached to `npm`, so they can reach `signoz-ingester`.
- Plaintext OTLP everywhere (ingester has no TLS): Traefik `grpc.insecure=true`, Immich/Komodo `http://`.
- Endpoint per app capability: Traefik & Komodo → gRPC `:4317`; Immich → HTTP `:4318`.
- `docker compose config` validates cleanly for all three stacks.

## How to verify in SigNoz
1. Let Komodo redeploy the `traefik`, `immich`, and `komodo` stacks.
2. Generate some traffic (visit a routed site, browse Immich, use the Komodo UI).
3. Open SigNoz → **APM / Services** tab; you should see: `traefik`, `immich`, `komodo-core`, `komodo-periphery`.