### PR TITLE
Pin stable host.name for otel-collector to stop SigNoz host churn

### DIFF
--- a/otel-collector/compose.yaml
+++ b/otel-collector/compose.yaml
@@ -13,6 +13,12 @@ services:
     user: "0:0"
     environment:
       - TZ=${TZ}
+      # Pin a stable host.name so SigNoz doesn't register a new host on every
+      # redeploy. The resourcedetection/system processor lists detectors as
+      # [env, system], so this env-based value takes precedence over Docker's
+      # random container hostname. Set OTEL_COLLECTOR_HOST in Komodo to the real
+      # Docker host name; defaults to `dockerhost` so it never churns.
+      - OTEL_RESOURCE_ATTRIBUTES=host.name=${OTEL_COLLECTOR_HOST:-dockerhost}
       # Credentials/identifiers for Prometheus scrape targets, referenced in
       # config.yaml as ${env:VAR}. Komodo injects these from the env files.
       - UPTIME_KUMA_METRICS_USER=${UPTIME_KUMA_METRICS_USER}


### PR DESCRIPTION
## Problem

The otel-collector keeps registering a **new host** in SigNoz (Infrastructure → Hosts) on every redeploy.

## Root cause

`otel-collector/config.yaml` uses the `resourcedetection/system` processor to set the `host.name` resource attribute. Docker assigns the collector container a new random hostname (equal to the container ID) every time it is recreated, so `host.name` changes on each redeploy and SigNoz treats it as a brand-new host.

## Fix

The `resourcedetection/system` processor already lists detectors in order `[env, system]`, so the `env` detector takes precedence. Adding a single environment variable to the `otel-collector` service pins a stable `host.name` that overrides the random container hostname — **no change to `config.yaml` is needed**:

```yaml
- OTEL_RESOURCE_ATTRIBUTES=host.name=${OTEL_COLLECTOR_HOST:-dockerhost}
```

The `${VAR:-default}` form means it works whether or not the operator sets the variable.

## Operator note

- Optionally set the new Komodo variable `OTEL_COLLECTOR_HOST` to your real Docker host's name. If unset, it defaults to the stable fallback `dockerhost`, so it never churns either way.
- The previously-created duplicate hosts in SigNoz can be ignored / aged out — only the stable host will appear going forward.

Pipelines, receivers, and the `signoz/` stack are unchanged.