### PR TITLE
feat(otel-collector): enrich docker_stats metrics for SigNoz Docker dashboard

### DIFF
--- a/otel-collector/config.yaml
+++ b/otel-collector/config.yaml
@@ -19,11 +19,21 @@ receivers:
         enabled: true
       container.memory.percent:
         enabled: true
+      container.memory.usage.limit:
+        enabled: true
+      container.memory.usage.total:
+        enabled: true
       container.network.io.usage.rx_bytes:
         enabled: true
       container.network.io.usage.tx_bytes:
         enabled: true
+      container.network.io.usage.rx_dropped:
+        enabled: true
+      container.network.io.usage.tx_dropped:
+        enabled: true
       container.blockio.io_service_bytes_recursive:
+        enabled: true
+      container.blockio.io_serviced_recursive:
         enabled: true
 
   # Host-level metrics (CPU, memory, disk, filesystem, network).
@@ -155,6 +165,9 @@ processors:
     detectors:
       - env
       - system
+      - docker
+    timeout: 2s
+    override: false
     system:
       hostname_sources:
         - os


### PR DESCRIPTION
## What

Surgical edits to `otel-collector/config.yaml` so SigNoz's prebuilt **Docker container metrics** dashboard fully populates from the existing OTel → SigNoz pipeline. No pipeline, receiver, exporter, or signoz/ stack changes.

Based on SigNoz's official doc: https://signoz.io/docs/metrics-management/docker-container-metrics/

## Changes

### 1. Newly enabled `docker_stats` metrics → dashboard panels unlocked

| Metric (newly enabled) | Dashboard panel it unlocks |
|---|---|
| `container.memory.usage.limit` | Memory limits / % of limit |
| `container.memory.usage.total` | Total memory usage |
| `container.network.io.usage.rx_dropped` | Network packets dropped (RX) |
| `container.network.io.usage.tx_dropped` | Network packets dropped (TX) |
| `container.blockio.io_serviced_recursive` | Block IO (operations count) |

Existing metrics kept as-is: `container.cpu.utilization`, `container.memory.percent`, `container.network.io.usage.rx_bytes`, `container.network.io.usage.tx_bytes`, `container.blockio.io_service_bytes_recursive`.

### 2. `resourcedetection/system`: detectors `[env, system]` → `[env, system, docker]`

The `docker` detector enriches metrics with host/OS metadata from the Docker daemon (the docker socket is already mounted read-only into the collector). Added `timeout: 2s` and `override: false` per SigNoz's recommended config.

**`env` stays FIRST** — this preserves the pinned `host.name` from `OTEL_RESOURCE_ATTRIBUTES` (PR #2180) that stops SigNoz host churn. `override: false` ensures the docker detector never clobbers the env-supplied host name.

## Validation

- `python3 -c "import yaml; yaml.safe_load(...)"` → YAML OK.
- Docker daemon not available in this environment, so the collector image's `validate --config` could not be run; syntax validated via YAML parse.

## Operator follow-up — import the prebuilt dashboard

Once Komodo deploys this to main:

1. In SigNoz: **Dashboards → New dashboard → Import JSON**
2. Import: https://github.com/SigNoz/dashboards/blob/main/container-metrics/docker/container-metrics-by-host.json

> Note: this intentionally reuses the existing OTel → SigNoz pipeline. The Prometheus + Grafana + cAdvisor approach was rejected as redundant.