### PR TITLE
chore(renovate): assign reviewer on automerge PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,6 +9,8 @@
   "dependencyDashboardHeader": "This issue contains a list of Renovate updates and statuses.",
   "timezone": "Europe/Amsterdam",
   "assigneesFromCodeOwners": true,
+  "reviewers": ["MichielMak"],
+  "assignAutomerge": true,
   "enabledManagers": [
     "docker-compose"
   ],


### PR DESCRIPTION
Adds `"reviewers": ["MichielMak"]` and `"assignAutomerge": true` to the Renovate config.

Without `assignAutomerge` (which defaults to `false`), Renovate skips requesting reviewers/assignees on any PR it intends to auto-merge — and since this config has `automerge: true`, no review would ever be requested. Setting it to `true` makes Renovate request MichielMak as reviewer even on automerge PRs.