### PR TITLE
ci: add Trivy image + config scan on PRs

### DIFF
--- a/.github/workflows/trivy-scan.yml
+++ b/.github/workflows/trivy-scan.yml
@@ -1,0 +1,98 @@
+name: Trivy Security Scan
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  config-scan:
+    name: Config scan (compose misconfig)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Trivy config scan
+        uses: aquasecurity/trivy-action@0.29.0
+        with:
+          scan-type: config
+          scan-ref: .
+          severity: HIGH,CRITICAL
+          exit-code: "1"
+          trivyignores: .trivyignore
+        env:
+          TRIVY_TIMEOUT: 10m
+
+  image-scan:
+    name: Image scan (changed stacks)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install Trivy
+        uses: aquasecurity/setup-trivy@v0.2.3
+        with:
+          version: v0.58.1
+
+      - name: Determine changed compose files
+        id: changed
+        run: |
+          set -euo pipefail
+          base="origin/${{ github.base_ref }}"
+          git fetch --quiet origin "${{ github.base_ref }}" || true
+          files=$(git diff --name-only "$base"...HEAD -- \
+            '**/compose.yaml' '**/compose.yml' \
+            '**/docker-compose.yaml' '**/docker-compose.yml' || true)
+          printf '%s\n' "$files" | sed '/^$/d' > changed_files.txt
+          echo "Changed compose files:"
+          cat changed_files.txt || true
+
+      - name: Extract and scan images
+        run: |
+          set -euo pipefail
+
+          if [ ! -s changed_files.txt ]; then
+            echo "No changed compose files detected. Nothing to scan."
+            exit 0
+          fi
+
+          # Extract every `image:` reference from the changed compose files,
+          # strip quotes/whitespace, and de-duplicate.
+          images=$(grep -hoE '^[[:space:]]*image:[[:space:]]*\S+' $(cat changed_files.txt) \
+            | sed -E 's/^[[:space:]]*image:[[:space:]]*//; s/["'\'']//g' \
+            | tr -d '[:space:]' \
+            | sort -u || true)
+
+          if [ -z "$images" ]; then
+            echo "No image references found in changed compose files."
+            exit 0
+          fi
+
+          echo "Images to scan:"
+          echo "$images"
+
+          fail=0
+          for img in $images; do
+            echo "::group::Scanning $img"
+            # --ignore-unfixed: only fail on vulnerabilities that have a fix
+            #   available (actionable — Renovate can bump to the patched image).
+            if ! trivy image \
+              --severity HIGH,CRITICAL \
+              --ignore-unfixed \
+              --exit-code 1 \
+              --no-progress \
+              --timeout 15m \
+              "$img"; then
+              echo "::error::Vulnerabilities found in $img"
+              fail=1
+            fi
+            echo "::endgroup::"
+          done
+
+          exit $fail

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,13 @@
+# Trivy ignore file
+# Suppress specific findings that are accepted risks or false positives.
+#
+# Image vulnerabilities: list the CVE ID, one per line, e.g.
+#   CVE-2023-12345
+#
+# Config (misconfig) checks: list the Trivy check ID, e.g.
+#   AVD-DS-0026
+#
+# Optionally scope + expire a suppression:
+#   CVE-2023-12345 exp:2026-12-31
+#
+# Keep this list curated — every entry is a vulnerability you're choosing to ship.


### PR DESCRIPTION
## What

Adds a GitHub Actions workflow (`.github/workflows/trivy-scan.yml`) that runs [Trivy](https://github.com/aquasecurity/trivy) on every pull request, plus a `.trivyignore` for curating accepted risks.

Two jobs:

- **Config scan (compose misconfig)** — `trivy config` over the repo, failing on `HIGH`/`CRITICAL` misconfigurations in compose files.
- **Image scan (changed stacks)** — extracts `image:` references from the compose files changed in the PR and runs `trivy image` on each, failing on **fixable** `HIGH`/`CRITICAL` CVEs (`--ignore-unfixed`, so failures are actionable — Renovate can bump to a patched image). Self-skips when no compose files changed.

## Why

Gates container changes (including Renovate digest bumps) before they land on `main`, where Komodo continuously deploys them.

## No path filter — intentional

The jobs run on **all** PRs rather than only when compose files change. This lets them be used safely as **required status checks**: a required check behind a `paths:` filter would never report on unrelated PRs and would block them forever.

## Follow-up (manual, needs admin/ruleset permission)

Add these two checks as required in the "Protect default branch" ruleset once this PR has run the workflow once:

- `Config scan (compose misconfig)`
- `Image scan (changed stacks)`

The CLI token used to automate this returned 404 on ruleset writes, so it must be done in the UI or with an admin-scoped token.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>