### PR TITLE
ci: fix Trivy workflow action and CLI versions

### DIFF
--- a/.github/workflows/trivy-scan.yml
+++ b/.github/workflows/trivy-scan.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Trivy config scan
-        uses: aquasecurity/trivy-action@0.29.0
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
           scan-type: config
           scan-ref: .
@@ -36,9 +36,9 @@ jobs:
           fetch-depth: 0
 
       - name: Install Trivy
-        uses: aquasecurity/setup-trivy@v0.2.3
+        uses: aquasecurity/setup-trivy@v0.3.1
         with:
-          version: v0.58.1
+          version: v0.72.0
 
       - name: Determine changed compose files
         id: changed


### PR DESCRIPTION
## Problem

The Trivy workflow merged in #2208 pinned action versions that don't exist:

- `aquasecurity/trivy-action@0.29.0`
- `aquasecurity/setup-trivy@v0.2.3`

Both jobs failed at "Set up job" (`unable to find version`), so `main`'s Trivy checks are currently red on every PR. Dependabot's #2209 bumps the two actions but leaves the pinned trivy CLI at `v0.58.1`, which **fails to install** with `setup-trivy` (`install.sh` finds the version, then exits 1) — so the image scan job still can't run.

## Fix

Pin known-good versions:

- `aquasecurity/trivy-action@v0.36.0`
- `aquasecurity/setup-trivy@v0.3.1`
- trivy CLI `v0.72.0`

Verified both jobs pass via a manual `workflow_dispatch` run on this branch.

**Supersedes #2209** (which only partially fixes the issue).

## Follow-up

Once this lands and the workflow is green, add these as required status checks in the "Protect default branch" ruleset:

- `Config scan (compose misconfig)`
- `Image scan (changed stacks)`

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>