### PR TITLE
Fix Trivy image scan collapsing image list into one invalid reference

### DIFF
--- a/.github/workflows/trivy-scan.yml
+++ b/.github/workflows/trivy-scan.yml
@@ -66,7 +66,7 @@ jobs:
           # strip quotes/whitespace, and de-duplicate.
           images=$(grep -hoE '^[[:space:]]*image:[[:space:]]*\S+' $(cat changed_files.txt) \
             | sed -E 's/^[[:space:]]*image:[[:space:]]*//; s/["'\'']//g' \
-            | tr -d '[:space:]' \
+            | tr -d '\r' \
             | sort -u || true)
 
           if [ -z "$images" ]; then


### PR DESCRIPTION
## Problem

The `Image scan (changed stacks)` job in `.github/workflows/trivy-scan.yml` was failing with:

```
FATAL  Fatal error  ... could not parse reference: node:24.1.0-alpine3.20@sha256:...renovate/renovate:43.251.0@sha256:...
```

This was **not a real vulnerability** — it was a bug in the image-extraction pipeline.

## Root cause

The extraction step used `tr -d '[:space:]'`, which strips **all** whitespace from the entire stream, including the newlines that separate each `image:` reference. When more than one changed stack was scanned, all images were concatenated into a single invalid reference that Trivy could not parse.

## Fix

`grep -oE '...\S+'` already yields whitespace-free tokens, so the `tr` was both unnecessary and destructive. Replaced it with `tr -d '\r'` to strip only carriage returns while preserving line separation.

```diff
    | sed -E 's/^[[:space:]]*image:[[:space:]]*//; s/["'\'']//g' \
-   | tr -d '[:space:]' \
+   | tr -d '\r' \
    | sort -u || true)
```

Verified locally that multi-stack changes now extract as separate, parseable image references.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>