### PR TITLE
Add docker compose pre-commit validation + CI

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,24 @@
+name: Pre-commit
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  pre-commit:
+    name: Run pre-commit hooks
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Run pre-commit
+        uses: pre-commit/action@v3.0.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,3 +6,11 @@ repos:
         args: [--strict]
         files: "(^|/)renovate\\.json5?$"
         verbose: true
+  - repo: local
+    hooks:
+      - id: docker-compose-config
+        name: Validate docker compose files
+        entry: bash -c 'for f in "$@"; do docker compose -f "$f" config --no-interpolate --quiet || exit 1; done' --
+        language: system
+        files: "(^|/)compose\\.ya?ml$"
+        verbose: true


### PR DESCRIPTION
## Summary

Adds automated validation of Docker Compose files, mirroring the existing renovate config check.

### Changes
- **`docker-compose-config` pre-commit hook** — validates every `compose.yaml`/`compose.yml` against the Compose schema on commit using `docker compose config --no-interpolate --quiet`. `--no-interpolate` skips variable substitution so Komodo `${VAR}` placeholders don't cause false failures. Catches YAML syntax errors and invalid/misspelled schema keys.
- **`pre-commit` CI workflow** — runs all pre-commit hooks (renovate + compose) on pull requests, so the checks are enforced repo-wide, not just for contributors who ran `pre-commit install` locally.

### Verification
- ✅ Hook passes against all 65 existing compose files
- ✅ Confirmed it fails on broken YAML and invalid schema keys (e.g. `portz:`)

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>