### PR TITLE
ci: comment on PR with Trivy findings when a scan fails

### DIFF
--- a/.github/workflows/trivy-scan.yml
+++ b/.github/workflows/trivy-scan.yml
@@ -32,7 +32,6 @@ jobs:
           trivy config . \
             --severity HIGH,CRITICAL \
             --ignorefile .trivyignore \
-            --no-progress \
             --exit-code 1 \
             --format table > config_report.txt 2>&1
           code=$?

--- a/.github/workflows/trivy-scan.yml
+++ b/.github/workflows/trivy-scan.yml
@@ -11,24 +11,80 @@ jobs:
   config-scan:
     name: Config scan (compose misconfig)
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Trivy config scan
-        uses: aquasecurity/trivy-action@v0.36.0
+      - name: Install Trivy
+        uses: aquasecurity/setup-trivy@v0.3.1
         with:
-          scan-type: config
-          scan-ref: .
-          severity: HIGH,CRITICAL
-          exit-code: "1"
-          trivyignores: .trivyignore
-        env:
-          TRIVY_TIMEOUT: 10m
+          version: v0.72.0
+
+      - name: Trivy config scan
+        id: scan
+        run: |
+          set -euo pipefail
+
+          set +e
+          trivy config . \
+            --severity HIGH,CRITICAL \
+            --ignorefile .trivyignore \
+            --no-progress \
+            --exit-code 1 \
+            --format table > config_report.txt 2>&1
+          code=$?
+          set -e
+
+          cat config_report.txt
+
+          if [ "$code" -ne 0 ]; then
+            {
+              echo "## 🛡️ Trivy config scan — HIGH/CRITICAL misconfigurations found"
+              echo
+              echo "The following misconfigurations must be resolved before merging."
+              echo
+              echo '```'
+              cat config_report.txt
+              echo '```'
+            } > config_comment.md
+            echo "found=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "found=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Post findings comment
+        if: >-
+          github.event_name == 'pull_request' &&
+          github.actor != 'dependabot[bot]' &&
+          steps.scan.outputs.found == 'true'
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: trivy-config-scan
+          path: config_comment.md
+
+      - name: Clear stale comment
+        if: >-
+          github.event_name == 'pull_request' &&
+          github.actor != 'dependabot[bot]' &&
+          steps.scan.outputs.found == 'false'
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: trivy-config-scan
+          delete: true
+
+      - name: Fail if misconfigurations found
+        if: steps.scan.outputs.found == 'true'
+        run: exit 1
 
   image-scan:
     name: Image scan (changed stacks)
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -41,7 +97,6 @@ jobs:
           version: v0.72.0
 
       - name: Determine changed compose files
-        id: changed
         run: |
           set -euo pipefail
           base="origin/${{ github.base_ref }}"
@@ -54,11 +109,13 @@ jobs:
           cat changed_files.txt || true
 
       - name: Extract and scan images
+        id: scan
         run: |
           set -euo pipefail
 
           if [ ! -s changed_files.txt ]; then
             echo "No changed compose files detected. Nothing to scan."
+            echo "found=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
@@ -71,28 +128,82 @@ jobs:
 
           if [ -z "$images" ]; then
             echo "No image references found in changed compose files."
+            echo "found=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
           echo "Images to scan:"
           echo "$images"
 
+          : > image_comment.md
           fail=0
           for img in $images; do
             echo "::group::Scanning $img"
-            # --ignore-unfixed: only fail on vulnerabilities that have a fix
-            #   available (actionable — Renovate can bump to the patched image).
-            if ! trivy image \
+            # --ignore-unfixed: only report/gate on vulnerabilities that have a
+            #   fix available (actionable — Renovate can bump to the patched image).
+            set +e
+            report=$(trivy image \
               --severity HIGH,CRITICAL \
               --ignore-unfixed \
-              --exit-code 1 \
               --no-progress \
               --timeout 15m \
-              "$img"; then
+              --exit-code 1 \
+              --format table \
+              "$img" 2>&1)
+            code=$?
+            set -e
+
+            echo "$report"
+
+            if [ "$code" -ne 0 ]; then
               echo "::error::Vulnerabilities found in $img"
+              {
+                echo "### \`$img\`"
+                echo
+                echo '```'
+                echo "$report"
+                echo '```'
+                echo
+              } >> image_comment.md
               fail=1
             fi
             echo "::endgroup::"
           done
 
-          exit $fail
+          if [ "$fail" -ne 0 ]; then
+            {
+              echo "## 🛡️ Trivy image scan — fixable HIGH/CRITICAL vulnerabilities found"
+              echo
+              echo "The images below have known vulnerabilities with fixes available. Update to a patched image (digest) before merging."
+              echo
+              cat image_comment.md
+            } > image_comment_final.md
+            mv image_comment_final.md image_comment.md
+            echo "found=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "found=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Post findings comment
+        if: >-
+          github.event_name == 'pull_request' &&
+          github.actor != 'dependabot[bot]' &&
+          steps.scan.outputs.found == 'true'
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: trivy-image-scan
+          path: image_comment.md
+
+      - name: Clear stale comment
+        if: >-
+          github.event_name == 'pull_request' &&
+          github.actor != 'dependabot[bot]' &&
+          steps.scan.outputs.found == 'false'
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: trivy-image-scan
+          delete: true
+
+      - name: Fail if vulnerabilities found
+        if: steps.scan.outputs.found == 'true'
+        run: exit 1


### PR DESCRIPTION
## What

Builds on the now-merged Trivy workflow (#2210) to **post a PR comment with the findings overview whenever a scan fails**.

Behavior:

- **On failure** (fixable HIGH/CRITICAL found): posts a sticky PR comment containing the Trivy findings table, and fails the check (gate unchanged).
- **On a clean run**: deletes any stale findings comment and passes.
- Reporting is decoupled from gating — the check still goes red on findings, you just also get a readable overview inline on the PR.

Two sticky comments (separate headers) — one for the config scan, one for the image scan — so each updates in place rather than piling up.

## Notes

- Adds `pull-requests: write` to the two jobs (needed to comment).
- **Skips commenting on Dependabot PRs** — Dependabot's `GITHUB_TOKEN` is read-only, so a comment there would fail. The scan still runs and gates; it just won't comment. Renovate (self-hosted, same-repo branches) is unaffected.
- Severity threshold unchanged: HIGH,CRITICAL, `--ignore-unfixed`.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>