### PR TITLE
ci: post compact Trivy comment to stay under GitHub's size limit

### DIFF
--- a/.github/workflows/trivy-scan.yml
+++ b/.github/workflows/trivy-scan.yml
@@ -32,7 +32,6 @@ jobs:
           trivy config . \
             --severity HIGH,CRITICAL \
             --ignorefile .trivyignore \
-            --no-progress \
             --exit-code 1 \
             --format table > config_report.txt 2>&1
           code=$?

--- a/.github/workflows/trivy-scan.yml
+++ b/.github/workflows/trivy-scan.yml
@@ -49,6 +49,12 @@ jobs:
               cat config_report.txt
               echo '```'
             } > config_comment.md
+            if [ "$(wc -c < config_comment.md)" -gt 60000 ]; then
+              run_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+              head -c 60000 config_comment.md > config_comment.trunc
+              printf '\n\n_Comment truncated. See the [Actions log](%s) for full details._\n' "$run_url" >> config_comment.trunc
+              mv config_comment.trunc config_comment.md
+            fi
             echo "found=true" >> "$GITHUB_OUTPUT"
           else
             echo "found=false" >> "$GITHUB_OUTPUT"
@@ -136,36 +142,56 @@ jobs:
 
           : > image_comment.md
           fail=0
+          run_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           for img in $images; do
             echo "::group::Scanning $img"
             # --ignore-unfixed: only report/gate on vulnerabilities that have a
             #   fix available (actionable — Renovate can bump to the patched image).
+            json="$(mktemp)"
             set +e
-            report=$(trivy image \
+            trivy image \
               --severity HIGH,CRITICAL \
               --ignore-unfixed \
               --no-progress \
               --timeout 15m \
               --exit-code 1 \
-              --format table \
-              "$img" 2>&1)
+              --format json \
+              --output "$json" \
+              "$img"
             code=$?
             set -e
 
-            echo "$report"
+            # Human-readable table in the job log (full detail lives here).
+            trivy convert --format table "$json" || cat "$json"
 
             if [ "$code" -ne 0 ]; then
               echo "::error::Vulnerabilities found in $img"
+              crit=$(jq '[.Results[]?.Vulnerabilities[]?] | unique_by(.VulnerabilityID + "|" + .PkgName) | map(select(.Severity == "CRITICAL")) | length' "$json")
+              high=$(jq '[.Results[]?.Vulnerabilities[]?] | unique_by(.VulnerabilityID + "|" + .PkgName) | map(select(.Severity == "HIGH")) | length' "$json")
+              total=$(jq '[.Results[]?.Vulnerabilities[]?] | unique_by(.VulnerabilityID + "|" + .PkgName) | length' "$json")
               {
                 echo "### \`$img\`"
                 echo
-                echo '```'
-                echo "$report"
-                echo '```'
+                echo "**${crit} CRITICAL, ${high} HIGH** fixable vulnerabilities"
+                echo
+                echo "| CVE | Package | Installed | Fixed | Severity |"
+                echo "| --- | --- | --- | --- | --- |"
+                jq -r '
+                  [.Results[]?.Vulnerabilities[]?]
+                  | unique_by(.VulnerabilityID + "|" + .PkgName)
+                  | sort_by(if .Severity == "CRITICAL" then 0 else 1 end)
+                  | .[:30][]
+                  | "| \(.VulnerabilityID) | \(.PkgName) | \(.InstalledVersion) | \(.FixedVersion // "-") | \(.Severity) |"
+                ' "$json"
+                if [ "$total" -gt 30 ]; then
+                  echo
+                  echo "_…and $((total - 30)) more. See the [Actions log]($run_url) for the full report._"
+                fi
                 echo
               } >> image_comment.md
               fail=1
             fi
+            rm -f "$json"
             echo "::endgroup::"
           done
 
@@ -178,6 +204,14 @@ jobs:
               cat image_comment.md
             } > image_comment_final.md
             mv image_comment_final.md image_comment.md
+
+            # Safety net: keep the comment under GitHub's 65536-char limit.
+            if [ "$(wc -c < image_comment.md)" -gt 60000 ]; then
+              head -c 60000 image_comment.md > image_comment.trunc
+              printf '\n\n_Comment truncated. See the [Actions log](%s) for full details._\n' "$run_url" >> image_comment.trunc
+              mv image_comment.trunc image_comment.md
+            fi
+
             echo "found=true" >> "$GITHUB_OUTPUT"
           else
             echo "found=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/trivy-scan.yml
+++ b/.github/workflows/trivy-scan.yml
@@ -11,24 +11,80 @@ jobs:
   config-scan:
     name: Config scan (compose misconfig)
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Trivy config scan
-        uses: aquasecurity/trivy-action@v0.36.0
+      - name: Install Trivy
+        uses: aquasecurity/setup-trivy@v0.3.1
         with:
-          scan-type: config
-          scan-ref: .
-          severity: HIGH,CRITICAL
-          exit-code: "1"
-          trivyignores: .trivyignore
-        env:
-          TRIVY_TIMEOUT: 10m
+          version: v0.72.0
+
+      - name: Trivy config scan
+        id: scan
+        run: |
+          set -euo pipefail
+
+          set +e
+          trivy config . \
+            --severity HIGH,CRITICAL \
+            --ignorefile .trivyignore \
+            --no-progress \
+            --exit-code 1 \
+            --format table > config_report.txt 2>&1
+          code=$?
+          set -e
+
+          cat config_report.txt
+
+          if [ "$code" -ne 0 ]; then
+            {
+              echo "## 🛡️ Trivy config scan — HIGH/CRITICAL misconfigurations found"
+              echo
+              echo "The following misconfigurations must be resolved before merging."
+              echo
+              echo '```'
+              cat config_report.txt
+              echo '```'
+            } > config_comment.md
+            echo "found=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "found=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Post findings comment
+        if: >-
+          github.event_name == 'pull_request' &&
+          github.actor != 'dependabot[bot]' &&
+          steps.scan.outputs.found == 'true'
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: trivy-config-scan
+          path: config_comment.md
+
+      - name: Clear stale comment
+        if: >-
+          github.event_name == 'pull_request' &&
+          github.actor != 'dependabot[bot]' &&
+          steps.scan.outputs.found == 'false'
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: trivy-config-scan
+          delete: true
+
+      - name: Fail if misconfigurations found
+        if: steps.scan.outputs.found == 'true'
+        run: exit 1
 
   image-scan:
     name: Image scan (changed stacks)
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -41,7 +97,6 @@ jobs:
           version: v0.72.0
 
       - name: Determine changed compose files
-        id: changed
         run: |
           set -euo pipefail
           base="origin/${{ github.base_ref }}"
@@ -54,11 +109,13 @@ jobs:
           cat changed_files.txt || true
 
       - name: Extract and scan images
+        id: scan
         run: |
           set -euo pipefail
 
           if [ ! -s changed_files.txt ]; then
             echo "No changed compose files detected. Nothing to scan."
+            echo "found=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
@@ -71,28 +128,82 @@ jobs:
 
           if [ -z "$images" ]; then
             echo "No image references found in changed compose files."
+            echo "found=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
           echo "Images to scan:"
           echo "$images"
 
+          : > image_comment.md
           fail=0
           for img in $images; do
             echo "::group::Scanning $img"
-            # --ignore-unfixed: only fail on vulnerabilities that have a fix
-            #   available (actionable — Renovate can bump to the patched image).
-            if ! trivy image \
+            # --ignore-unfixed: only report/gate on vulnerabilities that have a
+            #   fix available (actionable — Renovate can bump to the patched image).
+            set +e
+            report=$(trivy image \
               --severity HIGH,CRITICAL \
               --ignore-unfixed \
-              --exit-code 1 \
               --no-progress \
               --timeout 15m \
-              "$img"; then
+              --exit-code 1 \
+              --format table \
+              "$img" 2>&1)
+            code=$?
+            set -e
+
+            echo "$report"
+
+            if [ "$code" -ne 0 ]; then
               echo "::error::Vulnerabilities found in $img"
+              {
+                echo "### \`$img\`"
+                echo
+                echo '```'
+                echo "$report"
+                echo '```'
+                echo
+              } >> image_comment.md
               fail=1
             fi
             echo "::endgroup::"
           done
 
-          exit $fail
+          if [ "$fail" -ne 0 ]; then
+            {
+              echo "## 🛡️ Trivy image scan — fixable HIGH/CRITICAL vulnerabilities found"
+              echo
+              echo "The images below have known vulnerabilities with fixes available. Update to a patched image (digest) before merging."
+              echo
+              cat image_comment.md
+            } > image_comment_final.md
+            mv image_comment_final.md image_comment.md
+            echo "found=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "found=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Post findings comment
+        if: >-
+          github.event_name == 'pull_request' &&
+          github.actor != 'dependabot[bot]' &&
+          steps.scan.outputs.found == 'true'
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: trivy-image-scan
+          path: image_comment.md
+
+      - name: Clear stale comment
+        if: >-
+          github.event_name == 'pull_request' &&
+          github.actor != 'dependabot[bot]' &&
+          steps.scan.outputs.found == 'false'
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: trivy-image-scan
+          delete: true
+
+      - name: Fail if vulnerabilities found
+        if: steps.scan.outputs.found == 'true'
+        run: exit 1


### PR DESCRIPTION
## Problem

On PR #2205 (Renovate bumping `renovate/renovate`), the image scan correctly found fixable HIGH/CRITICAL vulnerabilities, but **no comment was posted**. The sticky-comment step failed with:

```
Validation Failed: Body is too long (maximum is 65536 characters)
```

`renovate/renovate` is a large image; the full Trivy findings table exceeded GitHub's hard 65,536-char comment limit, so the API rejected it.

## Fix

- **Image scan** now emits JSON and builds a **compact per-image summary**: severity counts + a de-duplicated CVE table (CVE / Package / Installed / Fixed / Severity), capped at 30 rows, with a link to the Actions log for the full report.
- The **full table is still printed to the job log** via `trivy convert --format table`.
- Added a **60k-char safety cap** to both the image and config comment bodies (truncates with a link to the log rather than failing).

Gate behavior unchanged (fixable HIGH/CRITICAL). Verified the `jq` summary logic locally.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>