### PR TITLE
ci: bump GitHub Actions off deprecated Node 20 to Node 24 majors

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 

--- a/.github/workflows/trivy-scan.yml
+++ b/.github/workflows/trivy-scan.yml
@@ -16,7 +16,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Install Trivy
         uses: aquasecurity/setup-trivy@v0.3.1
@@ -65,7 +65,7 @@ jobs:
           github.event_name == 'pull_request' &&
           github.actor != 'dependabot[bot]' &&
           steps.scan.outputs.found == 'true'
-        uses: marocchino/sticky-pull-request-comment@v2
+        uses: marocchino/sticky-pull-request-comment@v3
         with:
           header: trivy-config-scan
           path: config_comment.md
@@ -75,7 +75,7 @@ jobs:
           github.event_name == 'pull_request' &&
           github.actor != 'dependabot[bot]' &&
           steps.scan.outputs.found == 'false'
-        uses: marocchino/sticky-pull-request-comment@v2
+        uses: marocchino/sticky-pull-request-comment@v3
         with:
           header: trivy-config-scan
           delete: true
@@ -92,7 +92,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -222,7 +222,7 @@ jobs:
           github.event_name == 'pull_request' &&
           github.actor != 'dependabot[bot]' &&
           steps.scan.outputs.found == 'true'
-        uses: marocchino/sticky-pull-request-comment@v2
+        uses: marocchino/sticky-pull-request-comment@v3
         with:
           header: trivy-image-scan
           path: image_comment.md
@@ -232,7 +232,7 @@ jobs:
           github.event_name == 'pull_request' &&
           github.actor != 'dependabot[bot]' &&
           steps.scan.outputs.found == 'false'
-        uses: marocchino/sticky-pull-request-comment@v2
+        uses: marocchino/sticky-pull-request-comment@v3
         with:
           header: trivy-image-scan
           delete: true

--- a/.github/workflows/trivy-scheduled-scan.yml
+++ b/.github/workflows/trivy-scheduled-scan.yml
@@ -21,7 +21,7 @@ jobs:
       ISSUE_TITLE: "🛡️ Trivy scheduled scan — deployed image vulnerabilities"
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Install Trivy
         uses: aquasecurity/setup-trivy@v0.3.1


### PR DESCRIPTION
## Summary

GitHub Actions runners now default to Node 24 and emit Node.js 20 deprecation warnings for actions still pinned to Node 20-based majors. This bumps every affected action across `.github/workflows/` to its latest major that runs on Node 24.

## Changes

| Action | Before | After | Runtime |
| --- | --- | --- | --- |
| `actions/checkout` | `@v4` | `@v7` | node24 |
| `actions/setup-python` | `@v5` | `@v6` | node24 |
| `marocchino/sticky-pull-request-comment` | `@v2` | `@v3` | node24 |

Affected files:
- `.github/workflows/pre-commit.yml` — checkout, setup-python
- `.github/workflows/trivy-scan.yml` — checkout (×2), sticky-pull-request-comment (×4)
- `.github/workflows/trivy-scheduled-scan.yml` — checkout

## Audit notes

- `pre-commit/action@v3.0.1` and `aquasecurity/setup-trivy@v0.3.1` are **composite** actions (no Node runtime) — unaffected, left unchanged.
- New majors verified as node24 and behavior-compatible with our usage (`pull_request` triggers, simple inputs, `fetch-depth: 0` still supported). No syntax changes required.
- `renovate.json` and other files untouched.

Separate from PR #2217.