### PR TITLE
Enable Renovate github-actions manager

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -13,7 +13,8 @@
   "assignAutomerge": true,
   "enabledManagers": [
     "docker-compose",
-    "pip_requirements"
+    "pip_requirements",
+    "github-actions"
   ],
   "labels": [
     "renovate"
@@ -52,6 +53,17 @@
       "matchManagers": ["pip_requirements"],
       "matchPackageNames": ["playwright"],
       "enabled": false
+    },
+    {
+      "description": "Group GitHub Actions updates and label them",
+      "matchManagers": [
+        "github-actions"
+      ],
+      "groupName": "github-actions",
+      "groupSlug": "github-actions",
+      "addLabels": [
+        "github-actions"
+      ]
     },
     {
       "description": "Docker: allow only stable SemVer or CalVer",


### PR DESCRIPTION
## What

Enables the Renovate `github-actions` manager so action version pins in `.github/workflows/` receive automated update PRs.

## Why

`enabledManagers` is an allowlist that was restricted to `docker-compose` and `pip_requirements`. Because `github-actions` wasn't in the list, Renovate never opened PRs for GitHub Actions version bumps. This is why the Node 20 action deprecations had to be fixed manually in **PR #2218** — Renovate simply wasn't watching those files.

## Changes (only `renovate.json`)

- Add `"github-actions"` to `enabledManagers` (kept `"docker-compose"` and `"pip_requirements"`).
- Add a minimal `packageRule` that groups github-actions updates and applies a `github-actions` label, consistent with the repo's existing labeling style.

## Behavior

The repo's global config already sets `pinDigests: true` and `automerge: true`, and these apply to the github-actions manager automatically. Renovate will therefore pin actions to commit SHAs (e.g. `actions/checkout@<sha> # v7.0.0`), matching the Docker digest-pinning convention used throughout this repo. This is the desired behavior.

## Validation

- JSON verified well-formed.
- `renovate-config-validator` pre-commit hook passes.

No workflow files or other files were modified.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>