### PR TITLE
fix(wizarr): set PORT env var to fix healthcheck

### DIFF
--- a/wizarr/compose.yaml
+++ b/wizarr/compose.yaml
@@ -13,6 +13,7 @@ services:
       - TZ=Europe/Amsterdam #Set your timezone here
       - PUID=${PUID} #Set UID
       - PGID=${PGID} #Set GID
+      - PORT=5690
     restart: unless-stopped
     networks:
       - npm


### PR DESCRIPTION
## Summary
- `v2026.7.0` healthcheck runs `curl http://localhost:$PORT/health` but `PORT` was not set in the container environment
- Results in `curl http://localhost:/health` (invalid URL) → exit 1 → container permanently unhealthy
- App itself runs fine on port 5690; fix is simply setting `PORT=5690` in env

## Test plan
- [ ] Merge → Komodo redeploys → container shows `healthy` status