### PR TITLE
chore(wizarr): remove PORT workaround fixed in v2026.7.1

### DIFF
--- a/wizarr/compose.yaml
+++ b/wizarr/compose.yaml
@@ -13,7 +13,6 @@ services:
       - TZ=Europe/Amsterdam #Set your timezone here
       - PUID=${PUID} #Set UID
       - PGID=${PGID} #Set GID
-      - PORT=5690
     restart: unless-stopped
     networks:
       - npm


### PR DESCRIPTION
## Summary
- `PORT=5690` was added in #2231 as a workaround for a broken healthcheck in v2026.7.0
- v2026.7.1 fixes this upstream (wizarrrr/wizarr#1331)
- Workaround no longer needed

## Test plan
- [ ] Merge → Komodo redeploys → container stays healthy