### PR TITLE
fix: keep Trivy scan issue body within GitHub size limit

### DIFF
--- a/.github/workflows/trivy-scheduled-scan.yml
+++ b/.github/workflows/trivy-scheduled-scan.yml
@@ -63,7 +63,8 @@ jobs:
           echo "Images to scan:"
           echo "$images"
 
-          : > image_report.md
+          : > summary_report.md
+          : > detail_report.md
           fail=0
           for img in $images; do
             echo "::group::Scanning $img"
@@ -85,6 +86,16 @@ jobs:
 
             if [ "$code" -ne 0 ]; then
               echo "::warning::Vulnerabilities found in $img"
+
+              # Sum HIGH/CRITICAL across all targets in the report so the issue
+              # can show a compact per-image count without the full tables.
+              high=$(echo "$report" | grep -oE 'HIGH: [0-9]+' \
+                | awk -F': ' '{s+=$2} END {print s+0}')
+              crit=$(echo "$report" | grep -oE 'CRITICAL: [0-9]+' \
+                | awk -F': ' '{s+=$2} END {print s+0}')
+
+              echo "| \`$img\` | $high | $crit |" >> summary_report.md
+
               {
                 echo "### \`$img\`"
                 echo
@@ -92,22 +103,54 @@ jobs:
                 echo "$report"
                 echo '```'
                 echo
-              } >> image_report.md
+              } >> detail_report.md
               fail=1
             fi
             echo "::endgroup::"
           done
 
           if [ "$fail" -ne 0 ]; then
+            run_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+
             {
               echo "$ISSUE_TITLE"
               echo
               echo "The scheduled Trivy scan found **fixable HIGH/CRITICAL** vulnerabilities in images currently referenced on \`main\`. These emerged after merge and are not caught by the PR-triggered scan. Update the affected images (digests) to patched versions."
               echo
-              echo "_Last scan: $(date -u '+%Y-%m-%d %H:%M UTC') — [run](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID})_"
+              echo "_Last scan: $(date -u '+%Y-%m-%d %H:%M UTC') — [full report in the run logs]($run_url)_"
               echo
-              cat image_report.md
+              echo "| Image | HIGH | CRITICAL |"
+              echo "| --- | ---: | ---: |"
+              cat summary_report.md
+              echo
+              echo "<details><summary>Detailed vulnerability tables</summary>"
+              echo
+              cat detail_report.md
+              echo "</details>"
             } > issue_body.md
+
+            # GitHub caps issue bodies at 65536 chars; the GraphQL updateIssue
+            # mutation rejects anything longer. Truncate the detail section so a
+            # large scan still produces a valid (updatable) issue — the full
+            # tables always remain in the run logs.
+            max_bytes=60000
+            if [ "$(wc -c < issue_body.md)" -gt "$max_bytes" ]; then
+              echo "Issue body over ${max_bytes} bytes; truncating detail section."
+              {
+                echo "$ISSUE_TITLE"
+                echo
+                echo "The scheduled Trivy scan found **fixable HIGH/CRITICAL** vulnerabilities in images currently referenced on \`main\`. These emerged after merge and are not caught by the PR-triggered scan. Update the affected images (digests) to patched versions."
+                echo
+                echo "_Last scan: $(date -u '+%Y-%m-%d %H:%M UTC') — [full report in the run logs]($run_url)_"
+                echo
+                echo "> ⚠️ Too many findings to embed the full tables here. Only the per-image summary is shown below; see the [run logs]($run_url) for complete details."
+                echo
+                echo "| Image | HIGH | CRITICAL |"
+                echo "| --- | ---: | ---: |"
+                cat summary_report.md
+              } > issue_body.md
+            fi
+
             echo "found=true" >> "$GITHUB_OUTPUT"
           else
             echo "found=false" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Why

The weekly Trivy scheduled scan (issue #2216) looked like it stopped running. It actually did trigger on schedule, but the run failed at the last step with:

```
failed to update .../issues/2216: GraphQL: Body is too long (updateIssue)
```

## What was happening

The scan step works fine and finds fixable HIGH/CRITICAL vulnerabilities across many stacks. The old workflow pasted the **full** Trivy tables for every affected image into the issue body. GitHub caps an issue body at 65,536 characters, so once enough images had findings, the combined body went over the limit and GitHub rejected the update. That rejection failed the whole job, so no issue got updated and there was no notification — making it look like the scan never ran.

## The fix

The issue body now stays small and always valid to post:

- Leads with a compact per-image summary table (`Image | HIGH | CRITICAL`), counts summed across all Trivy targets per image.
- Wraps the full detailed tables in a collapsible `<details>` block.
- If the body would still exceed a safe cap (60,000 bytes), it drops the detailed tables and keeps just the summary, with a note pointing to the run logs.

The complete report is always available in the Actions run logs regardless.

No schedule or permission changes — the workflow was already firing weekly.