### PR TITLE
ci(trivy): keep scheduled scan green on findings, fail only on scan errors

### DIFF
--- a/.github/workflows/trivy-scheduled-scan.yml
+++ b/.github/workflows/trivy-scheduled-scan.yml
@@ -65,18 +65,23 @@ jobs:
 
           : > summary_report.md
           : > detail_report.md
+          : > error_report.md
           fail=0
+          scan_error=0
           for img in $images; do
             echo "::group::Scanning $img"
             # --ignore-unfixed: only report vulnerabilities that have a fix
             #   available (actionable — Renovate can bump to the patched image).
+            # --exit-code 2: findings return exit code 2, keeping them distinct
+            #   from Trivy's exit code 1 which signals a genuine scan error
+            #   (e.g. MANIFEST_UNKNOWN for a digest no longer in the registry).
             set +e
             report=$(trivy image \
               --severity HIGH,CRITICAL \
               --ignore-unfixed \
               --no-progress \
               --timeout 15m \
-              --exit-code 1 \
+              --exit-code 2 \
               --format table \
               "$img" 2>&1)
             code=$?
@@ -84,15 +89,17 @@ jobs:
 
             echo "$report"
 
-            if [ "$code" -ne 0 ]; then
+            if [ "$code" -eq 0 ]; then
+              echo "Clean: $img"
+            elif [ "$code" -eq 2 ]; then
               echo "::warning::Vulnerabilities found in $img"
 
               # Sum HIGH/CRITICAL across all targets in the report so the issue
               # can show a compact per-image count without the full tables.
               high=$(echo "$report" | grep -oE 'HIGH: [0-9]+' \
-                | awk -F': ' '{s+=$2} END {print s+0}')
+                | awk -F': ' '{s+=$2} END {print s+0}' || true)
               crit=$(echo "$report" | grep -oE 'CRITICAL: [0-9]+' \
-                | awk -F': ' '{s+=$2} END {print s+0}')
+                | awk -F': ' '{s+=$2} END {print s+0}' || true)
 
               echo "| \`$img\` | $high | $crit |" >> summary_report.md
 
@@ -105,6 +112,18 @@ jobs:
                 echo
               } >> detail_report.md
               fail=1
+            else
+              echo "::error::Scan failed for $img"
+
+              {
+                echo "### \`$img\` (scan error, exit $code)"
+                echo
+                echo '```'
+                echo "$report"
+                echo '```'
+                echo
+              } >> error_report.md
+              scan_error=1
             fi
             echo "::endgroup::"
           done
@@ -154,6 +173,15 @@ jobs:
             echo "found=true" >> "$GITHUB_OUTPUT"
           else
             echo "found=false" >> "$GITHUB_OUTPUT"
+          fi
+
+          # Fail the run only on genuine scan errors. Findings alone keep the
+          # run green — they are surfaced via the auto-opened issue.
+          if [ "$scan_error" -ne 0 ]; then
+            echo "::error::One or more images failed to scan (genuine errors)."
+            echo "Scan error details:"
+            cat error_report.md
+            exit 1
           fi
 
       - name: Open or update issue


### PR DESCRIPTION
## What
Modifies `.github/workflows/trivy-scheduled-scan.yml` so the scheduled scan no longer reports a failed run just because vulnerabilities were found, while still failing on genuine scan errors.

## Why
- Findings-only runs went red even though findings are already surfaced via the auto-opened GitHub issue.
- A genuine Trivy error (e.g. `MANIFEST_UNKNOWN` for a digest no longer in the registry, as with `ghcr.io/maziggy/bambuddy:0.2.4.9`) was indistinguishable from a real finding — misreported as vulnerabilities *and* failed the run.

## How
- Per-image scan now uses `--exit-code 2`, so **findings return exit 2**, distinct from Trivy's exit `1` used for real errors.
- Loop interprets the captured code: `0` = clean, `2` = vulnerabilities (record in summary/detail, set `fail`, emit `::warning::`), anything else = genuine error → recorded in `error_report.md`, prints `::error::Scan failed for <img>`, sets `scan_error=1`.
- End of step: findings but **no** scan errors → exit 0 (run stays green); any scan error → exit 1 (run fails and alerts).
- Findings still set `found=true`, so the Open/update issue and Close stale issue steps keep working as before.
- HIGH/CRITICAL count `grep`/`awk` lines hardened with `|| true` so a no-match doesn't abort under `set -euo pipefail`.

Severity thresholds and schedule unchanged. Validated with `yaml.safe_load` and `bash -n` on the extracted script.