### PR TITLE
fix(bambuddy): update digest — old manifest deleted from registry

### DIFF
--- a/bambuddy/compose.yaml
+++ b/bambuddy/compose.yaml
@@ -1,7 +1,7 @@
 services:
   bambuddy:
     container_name: bambuddy
-    image: ghcr.io/maziggy/bambuddy:0.2.4.9@sha256:cf1c213e93624fab93e96f7a737ace2dbfb046a5f61d62c434a892134a6113f0
+    image: ghcr.io/maziggy/bambuddy:0.2.4.9@sha256:d68ab4746f18c51a6e22f5cd536533a4ae3c1eb48f4eecccbb68c2be23d0ef52
     environment:
       - TZ=Europe/Amsterdam
       - PORT=8000


### PR DESCRIPTION
The pinned digest for `ghcr.io/maziggy/bambuddy:0.2.4.9` no longer exists in the registry (the maintainer overwrote the tag), causing the scheduled Trivy scan to fail.

This updates the digest to the current manifest for the same tag.