### PR TITLE
Add secret scanning and YAML checking pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,6 +6,16 @@ repos:
         args: [--strict]
         files: "(^|/)renovate\\.json5?$"
         verbose: true
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.30.1
+    hooks:
+      - id: gitleaks
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
+      - id: check-yaml
+        # Traefik dynamic configs are Go templates ({{ env "X" }}), not valid YAML
+        exclude: "^traefik/dynamic/"
   - repo: local
     hooks:
       - id: docker-compose-config


### PR DESCRIPTION
## What this does

Adds two new pre-commit hooks alongside the existing renovate and docker-compose validation:

- **gitleaks** — scans staged changes for accidentally committed secrets (API tokens, passwords, private keys). With 60+ services, this is a safety net that catches a real credential slipping in instead of a `${VAR}` placeholder.
- **check-yaml** — parses every YAML file and fails on syntax errors (bad indentation, unclosed quotes, duplicate keys) before they reach CI or Komodo.

## Note on the Traefik exclude

The `traefik/dynamic/*.yml` files are Go templates (e.g. `Host(\`x.{{ env "DOMAIN" }}\`)`). The nested double-quotes make them invalid YAML to a plain parser, even though Traefik renders them fine. So `check-yaml` skips that directory via an `exclude` rule. All other YAML (compose files, workflows) is still checked.

## Verification

Both hooks were run against the whole repo with `pre-commit run --all-files` and pass.