### PR TITLE
Authenticate Renovate with the GitHub App client id

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -50,7 +50,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.RENOVATE_APP_ID }}
+          client-id: ${{ secrets.RENOVATE_CLIENT_ID }}
           private-key: ${{ secrets.RENOVATE_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
           repositories: ${{ github.event.repository.name }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,7 +80,7 @@ labels:
 
 When adding a new service, Renovate will pick up the image automatically. If the image uses non-standard versioning, add a custom `packageRule` in `renovate.json`.
 
-Renovate runs hourly as a GitHub Actions workflow (`.github/workflows/renovate.yml`). It authenticates as a GitHub App using the `RENOVATE_APP_ID` and `RENOVATE_PRIVATE_KEY` repository secrets, and pulls Docker Hub metadata with `DOCKERHUB_USERNAME` / `DOCKERHUB_TOKEN`. The workflow can also be triggered manually, with options to reset or disable the repository cache.
+Renovate runs hourly as a GitHub Actions workflow (`.github/workflows/renovate.yml`). It authenticates as a GitHub App using the `RENOVATE_CLIENT_ID` and `RENOVATE_PRIVATE_KEY` repository secrets, and pulls Docker Hub metadata with `DOCKERHUB_USERNAME` / `DOCKERHUB_TOKEN`. The workflow can also be triggered manually, with options to reset or disable the repository cache.
 
 ## Adding a New Stack
 


### PR DESCRIPTION
Small follow-up to #2367. Swaps the deprecated `app-id` input for `client-id` in the token step.

## Why

Every Renovate run currently logs this warning:

```
Input 'app-id' has been deprecated with message: Use 'client-id' instead.
```

`actions/create-github-app-token` accepts two ways of identifying the app: the numeric App ID (the old way) or the Client ID (the new way). Both work today, but `app-id` is marked deprecated and will be removed in a future major version of the action. Since Renovate keeps that action up to date automatically, it is better to move now than to have a major version bump silently break authentication later.

Nothing else changes — same app, same private key, same permissions. Only the identifier used to look the app up.

## Setup

The `RENOVATE_CLIENT_ID` secret has already been added, so this can merge as-is.

The Client ID is the `Iv23li...` value shown on the app's settings page. Unlike the private key it is not a credential — it only names the app. The private key remains the thing that actually proves identity.

The old `RENOVATE_APP_ID` secret is now unused and can be deleted whenever convenient.

## Verification

After merging, trigger the workflow manually from the Actions tab. The run should complete without the deprecation annotation.