### PR TITLE
Restore Renovate coverage of the open_agb_firm repository

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -31,6 +31,13 @@ env:
   cache_dir: /tmp/renovate/cache/renovate/repository
   # Bump this value manually to invalidate every existing cache entry.
   cache_key: renovate-cache
+  # Repositories this Renovate instance manages. Both lists must be kept in
+  # sync: the token step wants names relative to the owner, while Renovate
+  # itself wants fully qualified names.
+  renovate_repos: |
+    docker-stacks
+    open_agb_firm
+  renovate_repositories: MichielMak/docker-stacks,MichielMak/open_agb_firm
 
 concurrency:
   group: renovate
@@ -53,7 +60,7 @@ jobs:
           client-id: ${{ secrets.RENOVATE_CLIENT_ID }}
           private-key: ${{ secrets.RENOVATE_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
-          repositories: ${{ github.event.repository.name }}
+          repositories: ${{ env.renovate_repos }}
 
       # The primary key contains the run id and attempt so every run stores a
       # fresh entry; `restore-keys` then picks the most recent previous entry.
@@ -82,7 +89,7 @@ jobs:
           LOG_LEVEL: ${{ inputs.logLevel || 'info' }}
           RENOVATE_PLATFORM: github
           RENOVATE_AUTODISCOVER: "false"
-          RENOVATE_REPOSITORIES: ${{ github.repository }}
+          RENOVATE_REPOSITORIES: ${{ env.renovate_repositories }}
           RENOVATE_REQUIRE_CONFIG: required
           RENOVATE_ONBOARDING: "false"
           RENOVATE_REPOSITORY_CACHE: ${{ inputs.repoCache || 'enabled' }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,7 +80,7 @@ labels:
 
 When adding a new service, Renovate will pick up the image automatically. If the image uses non-standard versioning, add a custom `packageRule` in `renovate.json`.
 
-Renovate runs hourly as a GitHub Actions workflow (`.github/workflows/renovate.yml`). It authenticates as a GitHub App using the `RENOVATE_CLIENT_ID` and `RENOVATE_PRIVATE_KEY` repository secrets, and pulls Docker Hub metadata with `DOCKERHUB_USERNAME` / `DOCKERHUB_TOKEN`. The workflow can also be triggered manually, with options to reset or disable the repository cache.
+Renovate runs hourly as a GitHub Actions workflow (`.github/workflows/renovate.yml`). It manages this repository and `MichielMak/open_agb_firm` — add further repositories to the `renovate_repos` and `renovate_repositories` lists at the top of the workflow. It authenticates as a GitHub App using the `RENOVATE_CLIENT_ID` and `RENOVATE_PRIVATE_KEY` repository secrets, and pulls Docker Hub metadata with `DOCKERHUB_USERNAME` / `DOCKERHUB_TOKEN`. The workflow can also be triggered manually, with options to reset or disable the repository cache.
 
 ## Adding a New Stack
 


### PR DESCRIPTION
Fixes a gap introduced by #2367: `MichielMak/open_agb_firm` stopped being covered by Renovate.

## What went wrong

The old self-hosted stack read its repository list from a `RENOVATE_REPOSITORIES` variable supplied by Komodo, which listed both `docker-stacks` and `open_agb_firm`. That value lived outside this repo, so it was not visible when the workflow was written — and the workflow was scoped to only the repository it lives in.

The result is that `open_agb_firm` has had no Renovate runs since the migration. Its config and dependency dashboard are still in place, so nothing is broken there; it simply stopped receiving update PRs.

## The fix

The managed repositories are now listed explicitly at the top of the workflow:

```yaml
renovate_repos: |
  docker-stacks
  open_agb_firm
renovate_repositories: MichielMak/docker-stacks,MichielMak/open_agb_firm
```

Two lists are needed because the two consumers expect different formats. The token step takes repository names relative to an owner, since it already knows the owner separately. Renovate wants fully qualified `owner/repo` names, because it supports running against multiple owners at once. They must be kept in sync — adding a repository means adding it to both.

Scoping the token to a named list rather than granting it every installed repository keeps the blast radius small if it ever leaks.

## Notes

Each repository keeps its own `renovate.json`; this only controls which repositories get visited. `open_agb_firm` manages Dockerfiles, GitHub Actions, and git submodules, which is unrelated to the Docker Compose rules here.

The repository cache stores each repository under its own path, so both share the single cache entry without interfering.

Expect a burst of PRs on `open_agb_firm` after the first run, covering the period it was skipped.

## Verification

Trigger the workflow manually after merging and confirm the log shows two `Repository started` / `Repository finished` pairs.