### PR TITLE
Re-enable Renovate digest updates for linuxserver images

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -231,6 +231,20 @@
       "enabled": false
     },
     {
+      "description": "LinuxServer.io re-points its short version tags on every rebuild (-lsNNN), so digest-only updates must stay enabled",
+      "matchDatasources": [
+        "docker"
+      ],
+      "matchPackageNames": [
+        "/^(?:docker\\.io\\/)?linuxserver\\//",
+        "/^lscr\\.io\\/linuxserver\\//"
+      ],
+      "matchUpdateTypes": [
+        "digest"
+      ],
+      "enabled": true
+    },
+    {
       "description": "The renovate-version workflow input takes a plain tag, so it must not be pinned to a digest",
       "matchManagers": [
         "custom.regex"


### PR DESCRIPTION
## Problem

Pinned linuxserver images stop getting updates and silently go stale.

Example — `plex/compose.yaml` is pinned to:

```
linuxserver/plex:1.43.3@sha256:59c671e1...   (built ~14 July)
```

but `linuxserver/plex:1.43.3` on Docker Hub currently points at:

```
sha256:d8b3417b...   (built 4 August, Plex 1.43.3.10861-07dfddaeb / ls318)
```

Three weeks of rebuilds missed, and Renovate never opened a PR.

## Why it happens

LinuxServer.io publishes a short tag (`1.43.3`) alongside a full one (`1.43.3.10861-07dfddaeb-ls318`). Every time they rebuild — new Plex build, base image patch, security fix — they bump the `-lsNNN` suffix and **re-point the short tag at the new digest**. For `1.43.3` alone that has already happened five times (ls314 → ls318).

So from Renovate's point of view the version never changes; only the digest does. And this existing rule turns those off:

```json
{
  "description": "Skip digest-only updates for versioned images — version bumps already bundle the new digest",
  "matchUpdateTypes": ["digest"],
  "matchCurrentVersion": "!/^(latest|stable|edge|...)$/i",
  "enabled": false
}
```

Its assumption — "a version bump will bring the new digest along" — holds for immutable tags, but not for rolling short tags like LinuxServer's. Result: no version bump, no digest bump, no update. Ever.

This affects all 16 linuxserver images in the repo, not just Plex.

## Fix

Add a narrow exception that re-enables digest-only updates for `linuxserver/*` (both Docker Hub and `lscr.io`). The general skip rule is untouched for every other image.

Renovate should open per-stack digest PRs on its next run and automerge them as usual.