### PR TITLE
fix(tracearr): correct image tag and pin digests

### DIFF
--- a/tracearr/compose.yaml
+++ b/tracearr/compose.yaml
@@ -7,10 +7,14 @@
 #   TRACEARR_JWT_SECRET      openssl rand -hex 32
 #   TRACEARR_COOKIE_SECRET   openssl rand -hex 32
 #   TRACEARR_DB_PASSWORD     database password
+#
+# NOTE: avoid "$" in these values. Compose interpolates the env file, so a
+# literal "$" is read as a variable reference (e.g. "pa$word" -> warning
+# 'The "w" variable is not set'). Use hex/alphanumeric values, or escape as "$$".
 
 services:
   tracearr:
-    image: ghcr.io/connorgallopo/tracearr:v2.0.1
+    image: ghcr.io/connorgallopo/tracearr:2.0.1@sha256:3d57d9b032b4a57919c48c919c16c3d6640b83f9116feb2c2cdf907747702ec8
     container_name: tracearr
     environment:
       - NODE_ENV=production
@@ -48,7 +52,7 @@ services:
     restart: unless-stopped
 
   tracearr-db:
-    image: timescale/timescaledb-ha:pg18.4-ts2.29.1
+    image: timescale/timescaledb-ha:pg18.4-ts2.29.1@sha256:5bcc34889e90cc21a4c67fc334b581ea3abc00f8e8d0a2eaf08d747ae69bd82f
     container_name: tracearr-db
     shm_size: 512mb
     ulimits:
@@ -78,7 +82,7 @@ services:
     restart: unless-stopped
 
   tracearr-redis:
-    image: redis:8-alpine
+    image: redis:8-alpine@sha256:978f0e01593e65eed801f2402944efcd936d43b5027e4908a7897baf88ed6241
     container_name: tracearr-redis
     command: redis-server --appendonly yes
     volumes:


### PR DESCRIPTION
## What

Fixes the `manifest unknown` error when deploying the tracearr stack.

## Why

The compose file used `ghcr.io/connorgallopo/tracearr:v2.0.1`, but upstream publishes tags without the `v` prefix. `2.0.1` exists, `v2.0.1` does not — so the pull failed and took the other two images down with it.

## Changes

- `tracearr` image tag `v2.0.1` → `2.0.1`
- Pinned all three images (tracearr, timescaledb-ha, redis) to SHA256 digests, matching the repo convention
- Added a comment about the `$` warning (see below)

## About the `The "w" variable is not set` warnings

That's unrelated to the image error and comes from the env values, not this file. Docker Compose interpolates the env file it reads, so a `$` inside a secret is treated as the start of a variable name — a password like `pa$word` becomes `pa` + the (unset) variable `w`. The password/secret would then be silently wrong.

Fix in Komodo: use values without `$` (e.g. `openssl rand -hex 32`), or escape each `$` as `$$`.